### PR TITLE
Add real responses using proxy results from mlab-ns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+- 1.13
+
+install:
+- go get -v -t ./...
+- go get github.com/mattn/goveralls
+
+script:
+- go vet ./...
+- go test ./... -cover=1 -coverprofile=_c.cov
+- go test ./... -race
+- $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # locate
+
+[![Coverage Status](https://coveralls.io/repos/github/m-lab/locate/badge.svg?branch=master)](https://coveralls.io/github/m-lab/locate?branch=master)
+
 M-Lab Locate Service, a load balancer providing consistent “expected measurement quality” using access control

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -47,7 +47,6 @@ func splitLatLon(latlon string) (string, string) {
 // TranslatedQuery uses the legacy mlab-ns service for liveness as a
 // transitional step in loading state directly.
 func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
-	// TODO: make request to mlab-ns and translate reply to v2.QueryReply.
 	result := v2.QueryResult{}
 	experiment, datatype := getDatatypeAndExperiment(req.URL.Path)
 	service := experiment + "/" + datatype

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -46,6 +46,8 @@ func NewClient(project string, private *token.Signer) *Client {
 	}
 }
 
+// splitLatLon attempts to split the "<lat>,<lon>" string provided by AppEngine
+// into two fields. The return values preserve the original lat,lon order.
 func splitLatLon(latlon string) (string, string) {
 	if fields := strings.Split(latlon, ","); len(fields) == 2 {
 		return fields[0], fields[1]

--- a/locate.go
+++ b/locate.go
@@ -20,6 +20,7 @@ var (
 )
 
 func init() {
+	// PORT and GOOGLE_CLOUD_PROJECT are part of the default App Engine environment.
 	flag.StringVar(&listenPort, "port", "8080", "AppEngine port environment variable")
 	flag.StringVar(&project, "google-cloud-project", "", "AppEngine project environment variable")
 	flag.StringVar(&signerKey, "encrypted-signer-key", "", "")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,81 @@
+// Package proxy issues requests to the legacy mlab-ns service and parses responses.
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/m-lab/locate/static"
+)
+
+var (
+	// LegacyServer controls the target service for requesting nearest machines.
+	LegacyServer = "mlab-ns.appspot.com"
+)
+
+type geoOptions []target
+
+type target struct {
+	FQDN string `json:"fqdn"`
+}
+
+// Nearest discovers the nearest machines for the target service, using a
+// proxied request to the LegacyServer such as mlab-ns.
+func Nearest(ctx context.Context, service, lat, lon string) ([]string, error) {
+	path, ok := static.LegacyServices[service]
+	if !ok {
+		return nil, fmt.Errorf("Unsupported service: %q", service)
+	}
+	latlon := ""
+	if lat != "" && lon != "" {
+		latlon = "&lat=" + lat + "&lon=" + lon
+	}
+	u := url.URL{
+		Scheme:   "https",
+		Host:     LegacyServer,
+		Path:     path,
+		RawQuery: "policy=geo_options" + latlon,
+	}
+	ctxTimeout, ctxCancel := context.WithTimeout(ctx, 20*time.Second)
+	defer ctxCancel()
+	req, err := http.NewRequestWithContext(ctxTimeout, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	opts := &geoOptions{}
+	err = json.Unmarshal(b, opts)
+	if err != nil {
+		return nil, err
+	}
+	return convert(opts), nil
+}
+
+// NOTE: this pattern assumes mlab-ns is returning flat host names, and should
+// be future compatible with project-decorated DNS names.
+var machinePattern = regexp.MustCompile("([a-z-]+)-(mlab[1-4][.-][a-z]{3}[0-9ct]{2}(\\.mlab-[a-z]+)?.measurement-lab.org)")
+
+func convert(opts *geoOptions) []string {
+	targets := []string{}
+	for _, opt := range *opts {
+		fields := machinePattern.FindStringSubmatch(opt.FQDN)
+		if len(fields) < 3 {
+			continue
+		}
+		targets = append(targets, fields[2])
+	}
+	return targets
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -4,6 +4,7 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -16,14 +17,18 @@ import (
 
 var (
 	// LegacyServer controls the target service for requesting nearest machines.
-	LegacyServer = "mlab-ns.appspot.com"
+	LegacyServer = url.URL{Scheme: "https", Host: "mlab-ns.appspot.com"}
 )
 
+// geoOptions and target are types for decoding native mlab-ns responses.
 type geoOptions []target
 
 type target struct {
 	FQDN string `json:"fqdn"`
 }
+
+// ErrNoContent is returned when mlab-ns returns http.StatusNoContent.
+var ErrNoContent = errors.New("no content from server")
 
 // Nearest discovers the nearest machines for the target service, using a
 // proxied request to the LegacyServer such as mlab-ns.
@@ -32,43 +37,54 @@ func Nearest(ctx context.Context, service, lat, lon string) ([]string, error) {
 	if !ok {
 		return nil, fmt.Errorf("Unsupported service: %q", service)
 	}
-	latlon := ""
+	params := url.Values{}
+	params.Set("policy", "geo_options")
 	if lat != "" && lon != "" {
-		latlon = "&lat=" + lat + "&lon=" + lon
+		params.Set("lat", lat)
+		params.Set("lon", lon)
 	}
-	u := url.URL{
-		Scheme:   "https",
-		Host:     LegacyServer,
-		Path:     path,
-		RawQuery: "policy=geo_options" + latlon,
-	}
+	u := LegacyServer
+	u.Path = path
+	u.RawQuery = params.Encode()
+
 	ctxTimeout, ctxCancel := context.WithTimeout(ctx, 20*time.Second)
 	defer ctxCancel()
 	req, err := http.NewRequestWithContext(ctxTimeout, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+	opts := &geoOptions{}
+	err = UnmarshalResponse(req, opts)
+	if err != nil {
+		return nil, err
+	}
+	return collect(opts), nil
+}
+
+// UnmarshalResponse reads the response from the given request and unmarshals
+// the value into the given result.
+func UnmarshalResponse(req *http.Request, result interface{}) error {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, err
+		return err
 	}
+	if resp.StatusCode == http.StatusNoContent {
+		// Cannot unmarshal empty content.
+		return ErrNoContent
+	}
+	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	opts := &geoOptions{}
-	err = json.Unmarshal(b, opts)
-	if err != nil {
-		return nil, err
-	}
-	return convert(opts), nil
+	return json.Unmarshal(b, result)
 }
 
 // NOTE: this pattern assumes mlab-ns is returning flat host names, and should
 // be future compatible with project-decorated DNS names.
 var machinePattern = regexp.MustCompile("([a-z-]+)-(mlab[1-4][.-][a-z]{3}[0-9ct]{2}(\\.mlab-[a-z]+)?.measurement-lab.org)")
 
-func convert(opts *geoOptions) []string {
+func collect(opts *geoOptions) []string {
 	targets := []string{}
 	for _, opt := range *opts {
 		fields := machinePattern.FindStringSubmatch(opt.FQDN)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,0 +1,321 @@
+// Package proxy issues requests to the legacy mlab-ns service and parses responses.
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/locate/static"
+)
+
+var legacyNames = `[
+  {
+    "ip": [
+      "128.177.119.203",
+      "2001:438:fffd:2b::203"
+    ],
+    "country": "US",
+    "city": "New York_NY",
+    "fqdn": "ndt-iupui-mlab1-lga06.measurement-lab.org",
+    "site": "lga06"
+  },
+  {
+    "ip": [
+      "4.35.94.37",
+      "2001:1900:2100:14::37"
+    ],
+    "country": "US",
+    "city": "New York_NY",
+    "fqdn": "ndt-iupui-mlab3-lga05.measurement-lab.org",
+    "site": "lga05"
+  }
+]`
+
+var projectNames = `[
+  {
+    "ip": [
+      "128.177.119.203",
+      "2001:438:fffd:2b::203"
+    ],
+    "country": "US",
+    "city": "New York_NY",
+    "fqdn": "ndt-mlab1-lga06.mlab-staging.measurement-lab.org",
+    "site": "lga06"
+  },
+  {
+    "ip": [
+      "4.35.94.37",
+      "2001:1900:2100:14::37"
+    ],
+    "country": "US",
+    "city": "New York_NY",
+    "fqdn": "ndt-mlab3-lga05.mlab-staging.measurement-lab.org",
+    "site": "lga05"
+  }
+]`
+
+var shortNames = `[
+  {
+    "ip": [
+      "64.86.148.152",
+      "2001:5a0:4300::152"
+    ],
+    "country": "US",
+    "city": "New York_NY",
+    "fqdn": "ndt-mlab2-lga03.measurement-lab.org",
+    "site": "lga03"
+  },
+  {
+    "ip": [
+      "38.106.70.165",
+      "2001:550:1d00:100::165"
+    ],
+    "country": "US",
+    "city": "New York_NY",
+    "fqdn": "ndt-mlab3-lga08.measurement-lab.org",
+    "site": "lga08"
+  }
+]`
+
+var badNames = `[
+  {
+    "ip": [
+      "64.86.148.152",
+      "2001:5a0:4300::152"
+    ],
+    "country": "US",
+    "city": "New York_NY",
+    "fqdn": "invalid-hostname.measurementlab.net",
+    "site": "lga03"
+  },
+  {
+    "ip": [
+      "38.106.70.165",
+      "2001:550:1d00:100::165"
+    ],
+    "country": "US",
+    "city": "New York_NY",
+    "fqdn": "invalid-hostname-2.measurementlab.net",
+    "site": "lga08"
+  }
+]`
+
+type fakeNS struct {
+	content     []byte
+	status      int
+	breakReader bool
+}
+
+func (f *fakeNS) defaultHandler(rw http.ResponseWriter, req *http.Request) {
+	if f.breakReader {
+		// Speicyfing a content length larger than the actual response generates
+		// a read error in the client.
+		rw.Header().Set("Content-Length", "8000")
+	}
+	rw.WriteHeader(f.status)
+	rw.Write([]byte(f.content))
+}
+
+func TestNearest(t *testing.T) {
+	tests := []struct {
+		name        string
+		service     string
+		lat         string
+		lon         string
+		content     string
+		status      int
+		breakReader bool
+		badScheme   string
+		badURL      string
+		want        []string
+		wantErr     bool
+	}{
+		{
+			name:    "success-legacy-names",
+			service: "ndt/ndt5",
+			lat:     "40.3",
+			lon:     "-70.1",
+			content: legacyNames,
+			status:  http.StatusOK,
+			want: []string{
+				"mlab1-lga06.measurement-lab.org", "mlab3-lga05.measurement-lab.org",
+			},
+		},
+		{
+			name:    "success-project-names",
+			service: "ndt/ndt5",
+			lat:     "40.3",
+			lon:     "-70.1",
+			content: projectNames,
+			status:  http.StatusOK,
+			want: []string{
+				"mlab1-lga06.mlab-staging.measurement-lab.org", "mlab3-lga05.mlab-staging.measurement-lab.org",
+			},
+		},
+		{
+			name:    "success-short-names",
+			service: "ndt/ndt5",
+			lat:     "40.3",
+			lon:     "-70.1",
+			content: shortNames,
+			status:  http.StatusOK,
+			want: []string{
+				"mlab2-lga03.measurement-lab.org", "mlab3-lga08.measurement-lab.org",
+			},
+		},
+		{
+			name:    "success-bad-names",
+			service: "ndt/ndt5",
+			lat:     "40.3",
+			lon:     "-70.1",
+			content: badNames,
+			status:  http.StatusOK,
+			want:    []string{},
+		},
+		{
+			name:    "error-no-content",
+			service: "ndt/ndt5",
+			lat:     "40.3",
+			lon:     "-70.1",
+			content: "",
+			status:  http.StatusNoContent,
+			wantErr: true,
+		},
+		{
+			name:        "bad-reader",
+			service:     "ndt/ndt5",
+			status:      http.StatusOK,
+			breakReader: true,
+			wantErr:     true,
+		},
+		{
+			name:    "bad-service",
+			service: "unknown-service-name",
+			status:  http.StatusOK,
+			wantErr: true,
+		},
+		{
+			name:      "bad-request",
+			service:   "ndt/ndt5",
+			badScheme: ":",
+			wantErr:   true,
+		},
+		{
+			name:    "bad-url",
+			service: "ndt/ndt5",
+			badURL:  "http://fake/this-does-not-exist",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeNS{
+				content:     []byte(tt.content),
+				status:      tt.status,
+				breakReader: tt.breakReader,
+			}
+			mux := http.NewServeMux()
+			mux.HandleFunc("/"+static.LegacyServices[tt.service], f.defaultHandler)
+			srv := httptest.NewServer(mux)
+			p, err := url.Parse(srv.URL)
+			rtx.Must(err, "failed to parse test server url")
+			LegacyServer = *p
+			if tt.badScheme != "" {
+				// While a url with a bad scheme can be converted using .String(),
+				// it will fail to parse again. This injects an error in NewRequestWithContext().
+				LegacyServer.Scheme = ":"
+			}
+			if tt.badURL != "" {
+				// Connections should fail to a bad url.
+				p, err := url.Parse(tt.badURL)
+				rtx.Must(err, "failed to parse test server url")
+				LegacyServer = *p
+			}
+
+			ctx := context.Background()
+			got, err := Nearest(ctx, tt.service, tt.lat, tt.lon)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Nearest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Nearest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_UnmarshalResponse(t *testing.T) {
+	type fakeObject struct {
+		Message string
+	}
+	tests := []struct {
+		name        string
+		url         string
+		result      interface{}
+		content     string
+		status      int
+		breakReader bool
+		wantErr     bool
+	}{
+		{
+			name:    "success",
+			result:  &fakeObject{},
+			content: `{"Message":"success"}`,
+			status:  http.StatusOK,
+		},
+		{
+			name:    "error-response",
+			url:     "http://fake/this-does-not-exist",
+			wantErr: true,
+		},
+		{
+			name:    "error-no-content",
+			content: "",
+			status:  http.StatusNoContent,
+			wantErr: true,
+		},
+		{
+			name:        "error-reader",
+			status:      http.StatusOK,
+			breakReader: true,
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &fakeNS{
+				content:     []byte(tt.content),
+				status:      tt.status,
+				breakReader: tt.breakReader,
+			}
+			srv := httptest.NewServer(http.HandlerFunc(f.defaultHandler))
+			url := srv.URL
+			if tt.url != "" {
+				// Override url with test url.
+				url = tt.url
+			}
+
+			req, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Errorf("failed to create request")
+			}
+			if err := UnmarshalResponse(req, tt.result); (err != nil) != tt.wantErr {
+				t.Errorf("getRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+
+			obj := tt.result.(*fakeObject)
+			if obj.Message != "success" {
+				t.Errorf("Result did not decode message: got %q, want 'success'", obj.Message)
+			}
+		})
+	}
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -222,23 +222,21 @@ func TestNearest(t *testing.T) {
 			mux := http.NewServeMux()
 			mux.HandleFunc("/"+static.LegacyServices[tt.service], f.defaultHandler)
 			srv := httptest.NewServer(mux)
-			p, err := url.Parse(srv.URL)
-			rtx.Must(err, "failed to parse test server url")
-			LegacyServer = *p
+			ll := MustNewLegacyLocator(srv.URL)
 			if tt.badScheme != "" {
 				// While a url with a bad scheme can be converted using .String(),
 				// it will fail to parse again. This injects an error in NewRequestWithContext().
-				LegacyServer.Scheme = ":"
+				ll.Server.Scheme = ":"
 			}
 			if tt.badURL != "" {
 				// Connections should fail to a bad url.
 				p, err := url.Parse(tt.badURL)
 				rtx.Must(err, "failed to parse test server url")
-				LegacyServer = *p
+				ll.Server = *p
 			}
 
 			ctx := context.Background()
-			got, err := Nearest(ctx, tt.service, tt.lat, tt.lon)
+			got, err := ll.Nearest(ctx, tt.service, tt.lat, tt.lon)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Nearest() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
This change adds support to the /v2/query resource for returning real results based on a translated response from mlab-ns.

This change adds a new package `proxy` which returns the "Nearest" machines to the client by using the App Engine provided lat/lon and forwarding those parameters to mlab-ns.

Only v2/query/ndt/ndt5 and v2/query/ndt/ndt7  targets are currently supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/2)
<!-- Reviewable:end -->
