### PR TITLE
Add support for loading KMS encrypted, private JWK signer keys

### DIFF
--- a/management/README.md
+++ b/management/README.md
@@ -1,0 +1,26 @@
+# Management of Locate Service JWK
+
+The locate service loads multiple JSON Web Keys (JWK) for signing and
+verifying signatures. To safely configure and deploy a private key in
+AppEngine, we rely on Google Key Management Service (KMS).
+
+In advance, an operator should create and encrypt a private JWK signing key
+using KMS via `create_encrypted_signer_key.sh`.
+
+The script `create_encrypted_signer_key.sh` produces the stanza that should
+be added to the app.yaml configuration. Because the KMS encrypion is
+per-project, each deployment will need it's own version of the encrypted key.
+And, because the key is encrypted, it can safely be added to a public
+repository.
+
+At start up, the locate service uses KMS to decrypt the signing key and then
+uses the resulting key to create a new token Signer that issues
+`access_tokens`. In turn, these access tokens are verified by target servers.
+
+It is the operator's responsibility to deploy the public JWK verifier key to
+all target servers.
+
+## TODO
+
+* Describe JWK management for
+  [m-lab/k8s-support](http://github.com/m-lab/k8s-support).

--- a/management/create_encrypted_signer_key.sh
+++ b/management/create_encrypted_signer_key.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# create_encrypted_signer_key.sh generates encrypted JWT signer keys and
+# creates the necessary KMS keyring and key.
+
+set -eu
+
+PROJECT=${1:?please provide project}
+KEYID=${2:?please provide keyid}
+
+GCPARGS="--project ${PROJECT}"
+
+KEYRING=locate-signer
+KEY=private-jwk
+
+# Create keyring if it's not already present.
+keyring=$(
+  gcloud ${GCPARGS} kms keyrings list \
+    --location global \
+    --format='value(name)' \
+    --filter "name~.*/${KEYRING}$" )
+if [[ -z ${keyring} ]] ; then
+  echo "Creating keyring: ${KEYRING}"
+  gcloud ${GCPARGS} kms keyrings create ${KEYRING} \
+    --location=global
+fi
+
+# Create key within keyring if it's not already present.
+key=$(
+  gcloud ${GCPARGS} kms keys list \
+    --location global \
+    --keyring ${KEYRING} \
+    --format='value(name)' \
+    --filter "name~.*/${KEY}$" )
+if [[ -z ${key} ]] ; then
+  echo "Creating key: ${KEY}"
+  gcloud kms keys create ${KEY} \
+    --location=global \
+    --keyring=${KEYRING} \
+    --purpose=encryption
+fi
+
+# Allow AppEngine service account to access key, if it doesn't already.
+binding=$(
+  gcloud ${GCPARGS} kms keys get-iam-policy ${KEY} \
+    --location global \
+    --keyring ${KEYRING} \
+    | grep serviceAccount:${PROJECT}@appspot.gserviceaccount.com || : )
+if [[ -z ${binding} ]]; then
+  echo "Binding iam policy for accessing ${KEYRING}/${KEY}"
+  gcloud kms keys add-iam-policy-binding ${KEY} \
+    --location=global \
+    --keyring=${KEYRING} \
+    --member=serviceAccount:${PROJECT}@appspot.gserviceaccount.com \
+    --role=roles/cloudkms.cryptoKeyDecrypter
+fi
+
+which jwk-keygen &> /dev/null || \
+    ( echo "Run: go get gopkg.in/square/go-jose.v2/jwk-keygen" && \
+    exit 1 )
+
+PRIVATE=jwk_sig_EdDSA_${KEYID}
+
+if [[ ! -f ${PRIVATE} ]] ; then
+  # Create JWK key.
+  echo "Creating private signer key: ${PRIVATE}"
+  jwk-keygen --use=sig --alg=EdDSA --kid=${KEYID}
+fi
+
+echo "Encrypting private signer key:"
+ENC_SIGNER_KEY=$( cat ${PRIVATE} | gcloud kms encrypt \
+  --plaintext-file=- \
+  --ciphertext-file=- \
+  --location=global \
+  --keyring=${KEYRING} \
+  --key=${KEY} | base64 )
+
+echo ""
+echo ""
+echo "Include the following in app.yaml:"
+echo ""
+echo "env_variables:"
+echo "  ENCRYPTED_SIGNER_KEY: \"${ENC_SIGNER_KEY}\""

--- a/management/create_encrypted_signer_key.sh
+++ b/management/create_encrypted_signer_key.sh
@@ -75,9 +75,13 @@ ENC_SIGNER_KEY=$( cat ${PRIVATE} | gcloud kms encrypt \
   --keyring=${KEYRING} \
   --key=${KEY} | base64 )
 
+# Replace all hyphens in project name with underscore to create a valid
+# environment variable.
+project=${PROJECT//-/_}
+
 echo ""
 echo ""
 echo "Include the following in app.yaml:"
 echo ""
 echo "env_variables:"
-echo "  ENCRYPTED_SIGNER_KEY: \"${ENC_SIGNER_KEY}\""
+echo "  ENCRYPTED_SIGNER_KEY_${project}: \"${ENC_SIGNER_KEY}\""

--- a/signer/load.go
+++ b/signer/load.go
@@ -1,0 +1,66 @@
+// Package signer loads encrypted keys from Google KMS.
+package signer
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/googleapis/gax-go"
+	"github.com/m-lab/access/token"
+
+	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
+)
+
+// Decrypter wraps the Decrypt operation provided by the kms.KeyManagementClient.
+type Decrypter interface {
+	Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error)
+}
+
+// Config contains settings for KMS decryption.
+type Config struct {
+	Project string
+	Region  string
+	Keyring string
+	Key     string
+}
+
+// NewConfig creates a new signer config.
+func NewConfig(project, region, keyring, key string) *Config {
+	return &Config{
+		Project: project,
+		Region:  region,
+		Keyring: keyring,
+		Key:     key,
+	}
+}
+
+// Load decrypts the ciphertext using the given KMS keypath and creates a new
+// token signer from the decrypted text.
+func (c *Config) Load(ctx context.Context, client Decrypter, ciphertext string) (*token.Signer, error) {
+	// ciphertext is base64 encoded; before decrypting, decode the ciphertext.
+	data, err := base64.StdEncoding.DecodeString(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare decrypt request parameters.
+	req := &kmspb.DecryptRequest{
+		Name:       c.path(),
+		Ciphertext: data,
+	}
+
+	// Decrypt the data.
+	resp, err := client.Decrypt(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// The plain text should be the original key.
+	return token.NewSigner(resp.Plaintext)
+}
+
+// path creates a GCP resource path for the KMS key referenced by Config.
+func (c *Config) path() string {
+	return "projects/" + c.Project + "/locations/" + c.Region +
+		"/keyRings/" + c.Keyring + "/cryptoKeys/" + c.Key
+}

--- a/signer/load_test.go
+++ b/signer/load_test.go
@@ -1,0 +1,121 @@
+// Package signer loads encrypted keys from Google KMS.
+package signer
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
+	"gopkg.in/square/go-jose.v2/jwt"
+
+	"github.com/googleapis/gax-go"
+	"github.com/m-lab/access/token"
+	"github.com/m-lab/go/rtx"
+)
+
+type fakeDecrypter struct {
+	text  string
+	err   error
+	given *kmspb.DecryptRequest
+}
+
+func (f *fakeDecrypter) Decrypt(ctx context.Context, req *kmspb.DecryptRequest, opts ...gax.CallOption) (*kmspb.DecryptResponse, error) {
+	var resp *kmspb.DecryptResponse
+	if f.err == nil {
+		resp = &kmspb.DecryptResponse{
+			Plaintext: []byte(f.text),
+		}
+	}
+	f.given = req
+	return resp, f.err
+}
+
+var (
+	insecurePrivateKey = `{"use":"sig","kty":"OKP","kid":"insecure","crv":"Ed25519","alg":"EdDSA","x":"E50_cwU7ACoH_XM6We3AFLHVWA63xm2crFhKL-PUc3Y","d":"3JRzWpk6aILrhOnry41Fu3u9l0XbloAVhuVNowWqT_Y"}`
+	insecurePublicKey  = `{"use":"sig","kty":"OKP","kid":"insecure","crv":"Ed25519","alg":"EdDSA","x":"E50_cwU7ACoH_XM6We3AFLHVWA63xm2crFhKL-PUc3Y"}`
+)
+
+func TestConfig_Load(t *testing.T) {
+	tests := []struct {
+		name       string
+		project    string
+		region     string
+		keyring    string
+		key        string
+		text       string
+		ciphertext string
+		err        error
+		wantErr    bool
+	}{
+		{
+			name:       "success",
+			project:    "mlab-testing",
+			region:     "global",
+			keyring:    "signer",
+			key:        "private-jwk",
+			text:       insecurePrivateKey,
+			ciphertext: base64.StdEncoding.EncodeToString([]byte(insecurePrivateKey)),
+		},
+		{
+			name:       "error-decoding",
+			project:    "mlab-testing",
+			region:     "global",
+			keyring:    "signer",
+			key:        "private-jwk",
+			ciphertext: "%%%%%%this-is-an-invalid-base64-string{}/:%%[]00",
+			wantErr:    true,
+		},
+		{
+			name:       "error-decrypting",
+			project:    "mlab-testing",
+			region:     "global",
+			keyring:    "signer",
+			key:        "private-jwk",
+			ciphertext: "abcdefghijklmnopqrstuvwxyz0123456789",
+			err:        errors.New("failure to decrypt"),
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewConfig(tt.project, tt.region, tt.keyring, tt.key)
+			ctx := context.Background()
+			client := &fakeDecrypter{
+				text: tt.text,
+				err:  tt.err,
+			}
+			signer, err := c.Load(ctx, client, tt.ciphertext)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Config.Load() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if signer == nil {
+				return
+			}
+
+			// Use the signer to generate and verify a claim.
+			cl := jwt.Claims{
+				Subject:  "subject",
+				Audience: jwt.Audience{"audience"},
+				Expiry:   jwt.NewNumericDate(time.Now().Add(time.Minute)),
+			}
+			tok, err := signer.Sign(cl)
+			rtx.Must(err, "failed to sign claim")
+			v, err := token.NewVerifier([]byte(insecurePublicKey))
+			rtx.Must(err, "failed to create verifier")
+			exp := jwt.Expected{
+				Subject:  "subject",
+				Audience: jwt.Audience{"audience"},
+				Time:     time.Now(),
+			}
+			cl2, err := v.Verify(tok, exp)
+			rtx.Must(err, "failed to verify")
+			if cl.Subject != cl2.Subject || !cl2.Audience.Contains(cl.Audience[0]) {
+				t.Errorf("Config.Load() = %v, want %v", cl2, cl)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds an operator script for creating and encrypting JWK signer keys. `create_encrypted_signer_key.sh`

This change adds a new package, `signer` for loading KMS encrypted private keys at runtime.

The combination of these two will provide support for the locate service to load a per-project JWK signer key at runtime and being issuing valid `access_tokens` in `/v2/query` replies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/3)
<!-- Reviewable:end -->
