### PR TITLE
Create distinct MonitoringResult type

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -43,9 +43,19 @@ type QueryResult struct {
 	Results []Target `json:"results,omitempty"`
 }
 
-// MonitoringResult reuses the QueryResult as a base. In practice, a
-// MonitoringResult will only have a single Target in Results.
-type MonitoringResult = QueryResult
+// MonitoringResult contains one Target with a single-purpose access-token
+// useful only for monitoring services on the target machine.
+type MonitoringResult struct {
+	// Error contains information about request failures.
+	Error *Error `json:"error,omitempty"`
+
+	// AccessToken is the access token used in Target URLs. Some applications
+	// may use this value instead of specific Target.URLs.
+	AccessToken string `json:"access_token"`
+
+	// Target contains service URLs for monitoring the service on the target machine.
+	Target *Target `json:"target,omitempty"`
+}
 
 // NextRequest contains a URL for scheduling the next request. The URL embeds an
 // access token that will be valid after `NotBefore`. The access token will

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -65,7 +65,7 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 	ports, ok := static.Configs[service]
 	if !ok {
 		result.Error = v2.NewError("config", "Unknown service: "+service, http.StatusBadRequest)
-		writeResult(rw, &result)
+		writeResult(rw, result.Error.Status, &result)
 		return
 	}
 
@@ -74,7 +74,7 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 	machines, err := c.Nearest(req.Context(), service, lat, lon)
 	if err != nil {
 		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", http.StatusInternalServerError)
-		writeResult(rw, &result)
+		writeResult(rw, result.Error.Status, &result)
 		return
 	}
 
@@ -86,10 +86,11 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 
 	// Populate each set of URLs using the ports configuration.
 	for i := range targets {
-		targets[i].URLs = c.getURLs(ports, targets[i].Machine, experiment, experiment)
+		token := c.getAccessToken(targets[i].Machine, experiment)
+		targets[i].URLs = c.getURLs(ports, targets[i].Machine, experiment, token)
 	}
 	result.Results = targets
-	writeResult(rw, &result)
+	writeResult(rw, http.StatusOK, &result)
 }
 
 // Heartbeat implements /v2/heartbeat requests.
@@ -97,12 +98,7 @@ func (c *Client) Heartbeat(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusNotImplemented)
 }
 
-// getURLs creates URLs for the named experiment, running on the named machine
-// for each given port. Every URL will include an `access_token=` parameter,
-// authorizing the measurement.
-func (c *Client) getURLs(ports static.Ports, machine, experiment, subject string) map[string]string {
-	urls := map[string]string{}
-
+func (c *Client) getAccessToken(machine, subject string) string {
 	// Create the token. The same access token is used for each target port.
 	cl := jwt.Claims{
 		Issuer:   static.IssuerLocate,
@@ -114,7 +110,14 @@ func (c *Client) getURLs(ports static.Ports, machine, experiment, subject string
 	// Sign errors can only happen due to a misconfiguration of the key.
 	// A good config will remain good.
 	rtx.PanicOnError(err, "signing claims has failed")
+	return token
+}
 
+// getURLs creates URLs for the named experiment, running on the named machine
+// for each given port. Every URL will include an `access_token=` parameter,
+// authorizing the measurement.
+func (c *Client) getURLs(ports static.Ports, machine, experiment, token string) map[string]string {
+	urls := map[string]string{}
 	// For each port config, prepare the target url with access_token and
 	// complete host field.
 	for name, target := range ports {
@@ -128,13 +131,11 @@ func (c *Client) getURLs(ports static.Ports, machine, experiment, subject string
 }
 
 // writeResult marshals the result and writes the result to the response writer.
-func writeResult(rw http.ResponseWriter, result *v2.QueryResult) {
+func writeResult(rw http.ResponseWriter, status int, result interface{}) {
 	b, err := json.MarshalIndent(result, "", "  ")
 	// Errors are only possible when marshalling incompatible types, like functions.
 	rtx.PanicOnError(err, "Failed to format result")
-	if result.Error != nil {
-		rw.WriteHeader(result.Error.Status)
-	}
+	rw.WriteHeader(status)
 	rw.Write(b)
 }
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -98,6 +98,8 @@ func (c *Client) Heartbeat(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusNotImplemented)
 }
 
+// getAccessToken allocates a new access token using the given machine name as
+// the intended audience and the subject as the target service.
 func (c *Client) getAccessToken(machine, subject string) string {
 	// Create the token. The same access token is used for each target port.
 	cl := jwt.Claims{

--- a/handler/monitoring_test.go
+++ b/handler/monitoring_test.go
@@ -102,16 +102,16 @@ func TestClient_Monitoring(t *testing.T) {
 				}
 				return
 			}
-			if len(q.Results) > 1 {
-				t.Errorf("Monitoring() returned wrong result count; got %d, want 1", len(q.Results))
+			if q.Target == nil {
+				t.Fatalf("Monitoring() returned nil Target")
 			}
-			if q.Results[0].Machine != tt.claim.Subject {
+			if q.Target.Machine != tt.claim.Subject {
 				t.Errorf("Monitoring() returned different machine than claim subject; got %s, want %s",
-					q.Results[0].Machine, tt.claim.Subject)
+					q.Target.Machine, tt.claim.Subject)
 			}
-			if len(q.Results[0].URLs) != len(static.Configs[tt.path]) {
+			if len(q.Target.URLs) != len(static.Configs[tt.path]) {
 				t.Errorf("Monitoring() returned incomplete urls; got %d, want %d",
-					len(q.Results[0].URLs), len(static.Configs[tt.path]))
+					len(q.Target.URLs), len(static.Configs[tt.path]))
 			}
 		})
 	}

--- a/static/configs.go
+++ b/static/configs.go
@@ -28,17 +28,17 @@ func URL(scheme, port, path string) url.URL {
 // service heartbeats register with the locate service.
 var Configs = map[string]Ports{
 	"ndt/ndt7": Ports{
-		"insecure-upload":   URL("http", "80", "/ndt/v7/upload"),
-		"insecure-download": URL("http", "80", "/ndt/v7/download"),
-		"upload":            URL("https", "443", "/ndt/v7/upload"),
-		"download":          URL("https", "443", "/ndt/v7/download"),
+		"ws/ndt/v7/upload":    URL("ws", "80", "/ndt/v7/upload"),
+		"ws/ndt/v7/download":  URL("ws", "80", "/ndt/v7/download"),
+		"wss/ndt/v7/upload":   URL("wss", "443", "/ndt/v7/upload"),
+		"wss/ndt/v7/download": URL("wss", "443", "/ndt/v7/download"),
 	},
 	"ndt/ndt5": Ports{
 		// TODO: should we report the raw port? Should we use the envelope
 		// service in a focused configuration? Should we retire the raw protocol?
 		// TODO: change ws port to 3002.
-		"ws":  URL("http", "3001", "/ndt_protocol"),
-		"wss": URL("https", "3010", "/ndt_protocol"),
+		"ws/ndt_protocol":  URL("ws", "3001", "/ndt_protocol"),
+		"wss/ndt_protocol": URL("wss", "3010", "/ndt_protocol"),
 	},
 	"wehe/replay": Ports{
 		"envelope": URL("https", "443", "/v0/allow"),


### PR DESCRIPTION
This change makes the MonitoringResult type distinct from the QueryResult. A MonitoringResult instance has a single AccessToken and Target field. Both of these are better aligned with the needs of monitoring than the original QueryResult type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/6)
<!-- Reviewable:end -->
