### PR TITLE
Derive URL keys from url templates

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -122,11 +122,12 @@ func (c *Client) getURLs(ports static.Ports, machine, experiment, token string) 
 	urls := map[string]string{}
 	// For each port config, prepare the target url with access_token and
 	// complete host field.
-	for name, target := range ports {
+	for _, target := range ports {
+		name := target.String()
 		params := url.Values{}
 		params.Set("access_token", token)
 		target.RawQuery = params.Encode()
-		target.Host = fmt.Sprintf("%s-%s:%s", experiment, machine, target.Host)
+		target.Host = fmt.Sprintf("%s-%s%s", experiment, machine, target.Host)
 		urls[name] = target.String()
 	}
 	return urls

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -52,6 +52,7 @@ func TestClient_TranslatedQuery(t *testing.T) {
 		locator    *fakeLocator
 		project    string
 		latlon     string
+		wantKey    string
 		wantStatus int
 	}{
 		{
@@ -75,6 +76,7 @@ func TestClient_TranslatedQuery(t *testing.T) {
 				machines: []string{"mlab1-lga0t.measurement-lab.org"},
 			},
 			latlon:     "40.3,-70.4",
+			wantKey:    "ws://:3001/ndt_protocol",
 			wantStatus: http.StatusOK,
 		},
 	}
@@ -114,6 +116,9 @@ func TestClient_TranslatedQuery(t *testing.T) {
 			if len(result.Results[0].URLs) != len(static.Configs[tt.path]) {
 				t.Errorf("TranslateQuery() result wrong URL count; got %d, want %d",
 					len(result.Results[0].URLs), len(static.Configs[tt.path]))
+			}
+			if _, ok := result.Results[0].URLs[tt.wantKey]; !ok {
+				t.Errorf("TranslateQuery() result missing URLs key; want %q", tt.wantKey)
 			}
 		})
 	}

--- a/handler/monitoring_test.go
+++ b/handler/monitoring_test.go
@@ -25,6 +25,7 @@ func TestClient_Monitoring(t *testing.T) {
 		locator         Locator
 		path            string
 		wantTokenPrefix string
+		wantKey         string
 		wantErr         *v2.Error
 	}{
 		{
@@ -39,7 +40,8 @@ func TestClient_Monitoring(t *testing.T) {
 			locator: &fakeLocator{
 				machines: []string{"mlab1-lga0t.measurement-lab.org"},
 			},
-			path: "ndt/ndt5",
+			path:    "ndt/ndt5",
+			wantKey: "wss://:3010/ndt_protocol",
 			// The fakeSigner generates synthetic access tokens based on the claim constructed by the handler.
 			// The audience (machine), the subject (monitoring), and issuer (locate). The suffix is the timestamp, which varies.
 			wantTokenPrefix: "mlab1-lga0t.mlab-oti.measurement-lab.org--monitoring--locate--",
@@ -123,6 +125,9 @@ func TestClient_Monitoring(t *testing.T) {
 			}
 			if strings.Contains(tt.wantTokenPrefix, q.AccessToken) {
 				t.Errorf("Monitoring() did not get access token;\ngot %s,\nwant %s", q.AccessToken, tt.wantTokenPrefix)
+			}
+			if _, ok := q.Target.URLs[tt.wantKey]; !ok {
+				t.Errorf("Monitoring() result missing URLs key; want %q", tt.wantKey)
 			}
 		})
 	}

--- a/static/configs.go
+++ b/static/configs.go
@@ -28,25 +28,25 @@ func URL(scheme, port, path string) url.URL {
 // service heartbeats register with the locate service.
 var Configs = map[string]Ports{
 	"ndt/ndt7": {
-		"ws/ndt/v7/upload":    URL("ws", "80", "/ndt/v7/upload"),
-		"ws/ndt/v7/download":  URL("ws", "80", "/ndt/v7/download"),
-		"wss/ndt/v7/upload":   URL("wss", "443", "/ndt/v7/upload"),
-		"wss/ndt/v7/download": URL("wss", "443", "/ndt/v7/download"),
+		URL("ws", "", "/ndt/v7/upload"),
+		URL("ws", "", "/ndt/v7/download"),
+		URL("wss", "", "/ndt/v7/upload"),
+		URL("wss", "", "/ndt/v7/download"),
 	},
 	"ndt/ndt5": {
 		// TODO: should we report the raw port? Should we use the envelope
 		// service in a focused configuration? Should we retire the raw protocol?
 		// TODO: change ws port to 3002.
-		"ws/ndt_protocol":  URL("ws", "3001", "/ndt_protocol"),
-		"wss/ndt_protocol": URL("wss", "3010", "/ndt_protocol"),
+		URL("ws", ":3001", "/ndt_protocol"),
+		URL("wss", ":3010", "/ndt_protocol"),
 	},
 	"wehe/replay": {
-		"envelope": URL("https", "443", "/v0/allow"),
+		URL("https", "", "/v0/allow"),
 	},
 }
 
 // Ports maps names to URLs.
-type Ports map[string]url.URL
+type Ports []url.URL
 
 // LegacyServices associates legacy mlab-ns experiment target names with their
 // v2 equivalent.


### PR DESCRIPTION
This change simplifies how service URL templates are stored and formatted as keys in the QueryResult and MonitoringResult URLs objects.

Example of this can be found:

https://locate-dot-mlab-sandbox.appspot.com/v2/query/ndt/ndt5
https://locate-dot-mlab-sandbox.appspot.com/v2/query/ndt/ndt7

Note, that this results in the ndt5 ports in the key strings.

This change also simplifies how clients will register supported services with the locate service via heartbeat. i.e. (<service_i>=<url-template_j>)+.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/8)
<!-- Reviewable:end -->
