### PR TITLE
Add production deployment config for locate/v2beta1

### DIFF
--- a/app.yaml.mlab-ns
+++ b/app.yaml.mlab-ns
@@ -1,0 +1,14 @@
+runtime: custom
+env: flex
+service: locate
+
+resources:
+  cpu: 2
+  memory_gb: 8
+
+manual_scaling:
+  instances: 2
+
+env_variables:
+  LOCATE_SIGNER_KEY: "CiQACaQCar+BO5frUJv1XYxMS+tjdBGdOa7tZDqb1L6zn38HWp8S3QEApOc0SqhOmXanuWUJK36obD1hA0Qg+JTkifO96fq6NnW0iMDuGVFEHp4LJkfpjcGDE5ibMhPFnb3SIGk9kMg54Qk/3HkNTGONjoY2xAKuuNG0kH3W5nvJS2AK452boMLvK74pQCCmJCvw0FTDQFrNDSdv/NMHRJCxCik2pbIbpAqGcj+6WB/jo3sqGzupdRpTdV5ErC5t0GETqopcC3XBnLJh+HbpK7rIn9dDgR8oJcSiG4xCYhZGOATbJ9V1/O3V+cuXFrH1qpqM/uSUdSO4clqUTBcpshPFY/Njiw=="
+  MONITORING_VERIFY_KEY: "CiQACaQCath3g+zc257EYcrN7fyhHDChcdlOHrgSeYMZSmd1jqsSrwEApOc0Silmr9MA0tvS+44Eo53p1tI6F9emIFYS4UP5BRhKCB4Svi5sFzGQUqgDlZq5AHGCwvIlzr4TvncpYvaBbtwccj/0W15ItNmzFwqq7mP0rqA/SVhv/8e6usfkFZIDVIuEXzjhf4jw56u2yttZgEhutOvMNUXExNh6TKZcMPaD8XX/LGgPF9qw7E8qTV7Rm7CVwyvzWR6hhpAUsRegTrH+YKgCNiox51o1HjZU"

--- a/locate.go
+++ b/locate.go
@@ -72,7 +72,7 @@ func main() {
 	// End to end monitoring requests access tokens for specific targets.
 	mux.Handle("/v2/monitoring/", monitoringChain)
 	// Clients request access tokens for specific services.
-	mux.HandleFunc("/v2/query/", http.HandlerFunc(c.TranslatedQuery))
+	mux.HandleFunc("/v2beta1/query/", http.HandlerFunc(c.TranslatedQuery))
 
 	srv := &http.Server{
 		Addr:    ":" + listenPort,


### PR DESCRIPTION
This PR adds an app.yaml configuration for deployment to mlab-ns project (production).

As well, this change modifies the `/v2/query` path to `/v2beta1/query`. The path allows for final v2 breaking changes while still providing early access to the v2/query api in a production context. In part this to support https://github.com/ooni/probe-engine/issues/562

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/11)
<!-- Reviewable:end -->
