### PR TITLE
Add support for multiple verifier keys

### DIFF
--- a/decrypt/load.go
+++ b/decrypt/load.go
@@ -69,12 +69,16 @@ func (c *Config) LoadSigner(ctx context.Context, client Decrypter, ciphertext st
 }
 
 // LoadVerifier decryptes the given ciphertext and uses it to initialize a token Verifier.
-func (c *Config) LoadVerifier(ctx context.Context, client Decrypter, ciphertext string) (*token.Verifier, error) {
-	b, err := c.Load(ctx, client, ciphertext)
-	if err != nil {
-		return nil, err
+func (c *Config) LoadVerifier(ctx context.Context, client Decrypter, ciphertext ...string) (*token.Verifier, error) {
+	keys := [][]byte{}
+	for i := range ciphertext {
+		b, err := c.Load(ctx, client, ciphertext[i])
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, b)
 	}
-	return token.NewVerifier(b)
+	return token.NewVerifier(keys...)
 }
 
 // path creates a GCP resource path for the KMS key referenced by Config.

--- a/locate.go
+++ b/locate.go
@@ -24,7 +24,7 @@ var (
 	listenPort          string
 	project             string
 	locateSignerKey     string
-	monitoringVerifyKey string
+	monitoringVerifyKey = flagx.StringArray{}
 )
 
 func init() {
@@ -32,7 +32,7 @@ func init() {
 	flag.StringVar(&listenPort, "port", "8080", "AppEngine port environment variable")
 	flag.StringVar(&project, "google-cloud-project", "", "AppEngine project environment variable")
 	flag.StringVar(&locateSignerKey, "locate-signer-key", "", "Private key of the locate+service key pair")
-	flag.StringVar(&monitoringVerifyKey, "monitoring-verify-key", "", "Public key of the monitoring+locate key pair")
+	flag.Var(&monitoringVerifyKey, "monitoring-verify-key", "Public keys of the monitoring+locate key pair")
 }
 
 var mainCtx, mainCancel = context.WithCancel(context.Background())
@@ -53,7 +53,7 @@ func main() {
 	c := handler.NewClient(project, signer, locator)
 
 	// MONITORING VERIFIER - for access tokens provided by monitoring.
-	verifier, err := cfg.LoadVerifier(mainCtx, client, monitoringVerifyKey)
+	verifier, err := cfg.LoadVerifier(mainCtx, client, monitoringVerifyKey...)
 	rtx.Must(err, "Failed to create verifier")
 	exp := jwt.Expected{
 		Issuer:   static.IssuerMonitoring,

--- a/management/README.md
+++ b/management/README.md
@@ -20,6 +20,28 @@ uses the resulting key to create a new token Signer that issues
 It is the operator's responsibility to deploy the public JWK verifier key to
 all target servers.
 
+## Key Rotation
+
+Periodically, the signing key should be rotated. To ensure continuity of
+verification, clients must posess both the current and next verifier key. A
+successful key rotation would follow these steps:
+
+1. Create a new key pair.
+
+    `./create_encrypted_signer_key.sh ${PROJECT} $( date +%Y%m%d )`
+
+2. Distribute the new verifier key to all clients of the new signer key.
+
+    * Copy verifier key to k8s-support for ndt-server and access envelope.
+    * Create a new production release including the new key.
+
+3. Promote the new signer key.
+
+    * Copy signer key to locate app.yaml configs
+    * Create a new production release including the new key.
+
+Follow similar steps for rotating the monitoring key pairs.
+
 ## TODO
 
 * Describe JWK management for


### PR DESCRIPTION
This change allows the configuration to specify multiple monitoring verifier keys. As well, this adds some documentation for key rotation, which requires support for multiple verify keys in the locate server as well as other services that verify access tokens, such as the ndt-server and access envelope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/13)
<!-- Reviewable:end -->
