### PR TITLE
Add CORS policy for /v2beta1/query handler

### DIFF
--- a/cmd/monitoring-token/monitoring-token.go
+++ b/cmd/monitoring-token/monitoring-token.go
@@ -85,7 +85,7 @@ func main() {
 
 	// Get monitoring result.
 	mr := &v2.MonitoringResult{}
-	err = proxy.UnmarshalResponse(req, mr)
+	_, err = proxy.UnmarshalResponse(req, mr)
 	rtx.Must(err, "Failed to get response")
 	logx.Debug.Println(pretty.Sprint(mr))
 	if mr.Error != nil {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -62,6 +62,9 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 	result := v2.QueryResult{}
 	experiment, service := getExperimentAndService(req.URL.Path)
 
+	// Set CORS policy to allow third-party websites to use returned resources.
+	rw.Header().Set("Access-Control-Allow-Origin", "*")
+
 	// Check whether the service is valid before all other steps to fail fast.
 	ports, ok := static.Configs[service]
 	if !ok {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -63,6 +63,7 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 	experiment, service := getExperimentAndService(req.URL.Path)
 
 	// Set CORS policy to allow third-party websites to use returned resources.
+	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set("Access-Control-Allow-Origin", "*")
 
 	// Check whether the service is valid before all other steps to fail fast.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -94,11 +94,14 @@ func TestClient_TranslatedQuery(t *testing.T) {
 			req.Header.Set("X-AppEngine-CityLatLong", tt.latlon)
 
 			result := &v2.QueryResult{}
-			err = proxy.UnmarshalResponse(req, result)
+			resp, err := proxy.UnmarshalResponse(req, result)
 			if err != nil {
 				t.Fatalf("Failed to get response from: %s %s", srv.URL, tt.path)
 			}
-
+			if resp.Header.Get("Access-Control-Allow-Origin") != "*" {
+				t.Errorf("TranslatedQuery() wrong Access-Control-Allow-Origin header; got %s, want '*'",
+					resp.Header.Get("Access-Control-Allow-Origin"))
+			}
 			if result.Error != nil && result.Error.Status != tt.wantStatus {
 				t.Errorf("TranslatedQuery() wrong status; got %d, want %d", result.Error.Status, tt.wantStatus)
 			}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -102,6 +102,10 @@ func TestClient_TranslatedQuery(t *testing.T) {
 				t.Errorf("TranslatedQuery() wrong Access-Control-Allow-Origin header; got %s, want '*'",
 					resp.Header.Get("Access-Control-Allow-Origin"))
 			}
+			if resp.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("TranslatedQuery() wrong Content-Type header; got %s, want 'application/json'",
+					resp.Header.Get("Content-Type"))
+			}
 			if result.Error != nil && result.Error.Status != tt.wantStatus {
 				t.Errorf("TranslatedQuery() wrong status; got %d, want %d", result.Error.Status, tt.wantStatus)
 			}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -72,7 +72,7 @@ func (ll *LegacyLocator) Nearest(ctx context.Context, service, lat, lon string) 
 		return nil, err
 	}
 	opts := &geoOptions{}
-	err = UnmarshalResponse(req, opts)
+	_, err = UnmarshalResponse(req, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -81,21 +81,21 @@ func (ll *LegacyLocator) Nearest(ctx context.Context, service, lat, lon string) 
 
 // UnmarshalResponse reads the response from the given request and unmarshals
 // the value into the given result.
-func UnmarshalResponse(req *http.Request, result interface{}) error {
+func UnmarshalResponse(req *http.Request, result interface{}) (*http.Response, error) {
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return resp, err
 	}
 	if resp.StatusCode == http.StatusNoContent {
 		// Cannot unmarshal empty content.
-		return ErrNoContent
+		return resp, ErrNoContent
 	}
 	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return resp, err
 	}
-	return json.Unmarshal(b, result)
+	return resp, json.Unmarshal(b, result)
 }
 
 // collect reads all FQDN results from the given options and guarantees to

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -303,13 +303,16 @@ func Test_UnmarshalResponse(t *testing.T) {
 			if err != nil {
 				t.Errorf("failed to create request")
 			}
-			if err := UnmarshalResponse(req, tt.result); (err != nil) != tt.wantErr {
+			resp, err := UnmarshalResponse(req, tt.result)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("getRequest() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.wantErr {
 				return
 			}
-
+			if resp.StatusCode != tt.status {
+				t.Errorf("UnmarshalResponse() got %d, want %d", resp.StatusCode, tt.status)
+			}
 			obj := tt.result.(*fakeObject)
 			if obj.Message != "success" {
 				t.Errorf("Result did not decode message: got %q, want 'success'", obj.Message)


### PR DESCRIPTION
This change sets the `Access-Control-Allow-Origin` response header to grant the widest permission for browsers to use the resources returned by the locate API.

Fixes https://github.com/m-lab/locate/issues/15

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/16)
<!-- Reviewable:end -->
