### PR TITLE
Add Location metadata to results

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -77,6 +77,12 @@ type NextRequest struct {
 	URL string `json:"url"`
 }
 
+// Location contains metadata about the geographic location of a target machine.
+type Location struct {
+	City    string `json:"city"`
+	Country string `json:"country"`
+}
+
 // Target contains information needed to run a measurement to a measurement
 // service on a single M-Lab machine. Measurement services may support multiple
 // resources. A Target contains at least one measurement service resource in
@@ -84,6 +90,9 @@ type NextRequest struct {
 type Target struct {
 	// Machine is the FQDN of the machine hosting the measurement service.
 	Machine string `json:"machine"`
+
+	// Location contains metadata about the geographic location of the target machine.
+	Location *Location `json:"location,omitempty"`
 
 	// URLs contains measurement service resource names and the complete URL for
 	// running a measurement.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -33,15 +33,15 @@ func (s *fakeSigner) Sign(cl jwt.Claims) (string, error) {
 }
 
 type fakeLocator struct {
-	err      error
-	machines []string
+	err     error
+	targets []v2.Target
 }
 
-func (l *fakeLocator) Nearest(ctx context.Context, service, lat, lon string) ([]string, error) {
+func (l *fakeLocator) Nearest(ctx context.Context, service, lat, lon string) ([]v2.Target, error) {
 	if l.err != nil {
 		return nil, l.err
 	}
-	return l.machines, nil
+	return l.targets, nil
 }
 
 func TestClient_TranslatedQuery(t *testing.T) {
@@ -73,7 +73,7 @@ func TestClient_TranslatedQuery(t *testing.T) {
 			path:   "ndt/ndt5",
 			signer: &fakeSigner{},
 			locator: &fakeLocator{
-				machines: []string{"mlab1-lga0t.measurement-lab.org"},
+				targets: []v2.Target{{Machine: "mlab1-lga0t.measurement-lab.org"}},
 			},
 			latlon:     "40.3,-70.4",
 			wantKey:    "ws://:3001/ndt_protocol",
@@ -116,9 +116,9 @@ func TestClient_TranslatedQuery(t *testing.T) {
 				t.Errorf("TranslatedQuery() wrong status; got %d, want %d", result.Error.Status, tt.wantStatus)
 			}
 			//	pretty.Print(result)
-			if len(tt.locator.machines) != len(result.Results) {
+			if len(tt.locator.targets) != len(result.Results) {
 				t.Errorf("TranslateQuery() wrong result count; got %d, want %d",
-					len(result.Results), len(tt.locator.machines))
+					len(result.Results), len(tt.locator.targets))
 			}
 			if len(result.Results[0].URLs) != len(static.Configs[tt.path]) {
 				t.Errorf("TranslateQuery() result wrong URL count; got %d, want %d",

--- a/handler/monitoring_test.go
+++ b/handler/monitoring_test.go
@@ -38,7 +38,7 @@ func TestClient_Monitoring(t *testing.T) {
 			},
 			signer: &fakeSigner{},
 			locator: &fakeLocator{
-				machines: []string{"mlab1-lga0t.measurement-lab.org"},
+				targets: []v2.Target{{Machine: "mlab1-lga0t.measurement-lab.org"}},
 			},
 			path:    "ndt/ndt5",
 			wantKey: "wss://:3010/ndt_protocol",


### PR DESCRIPTION
This change adds a `Location` field to the `v2.Target` type to report the `city` and `country`  of the target server.

This change preserves some functionality provided by mlab-ns and requested by several early adopters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/18)
<!-- Reviewable:end -->
