### PR TITLE
Add /v2/priority resource

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -78,6 +78,9 @@ func main() {
 	// Clients request access tokens for specific services.
 	mux.HandleFunc("/v2beta1/query/", http.HandlerFunc(c.TranslatedQuery))
 
+	// REQUIRED: API keys parameters required for priority requests.
+	mux.HandleFunc("/v2/priority/nearest/", http.HandlerFunc(c.TranslatedQuery))
+
 	srv := &http.Server{
 		Addr:    ":" + listenPort,
 		Handler: mux,


### PR DESCRIPTION
This change adds the v2/priority target planned for the apikey-required requests. By adding this now, clients using API keys can migrate immediately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/19)
<!-- Reviewable:end -->
