### PR TITLE
Restore API key security

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -139,9 +139,8 @@ paths:
             request in the event of error.
           schema:
             $ref: "#/definitions/ErrorResult"
-      # TODO(soltesz): enable after resolving the onebox API key requirements.
-      #security:
-      #- api_key: []
+      security:
+      - api_key: []
 
 definitions:
   # Define the query reply without being specific about the structure.


### PR DESCRIPTION
API key security was temporarily disabled pending complete HTTP referer patterns for one API key user. That is now complete. It should be safe to re-enable API key security, which this change does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/24)
<!-- Reviewable:end -->
