### PR TITLE
Change type to NearestResult

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -39,12 +39,12 @@ healthy in a geographic region. The locate API may return an error when no
 servers are available.
 
 > PLANNED(v2): in all cases above, the locate API will return a recommended
-[v2.QueryResult.NextRequest][nextRequest] time and signed URL for the client
+[v2.NearestResult.NextRequest][nextRequest] time and signed URL for the client
 to issue the next request. This will make retry logic in clients simpler and
 encourages best practices for the API. See the [request priority
 hierarchy][priority].
 
-[nextRequest]: https://godoc.org/github.com/m-lab/locate/api/v2#QueryResult
+[nextRequest]: https://godoc.org/github.com/m-lab/locate/api/v2#NearestResult
 [priority]: https://godoc.org/github.com/m-lab/locate/api/v2
 [aup]: https://www.measurementlab.net/aup
 

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -13,14 +13,14 @@
 //  NO      | NO           | Global Best Effort Pool
 //
 // For highest priority access to the platform, register an API key and use the
-// QueryResult.NextRequest.URL when provided.
+// NearestResult.NextRequest.URL when provided.
 package v2
 
 import "time"
 
-// QueryResult is returned by the location service in response to query
+// NearestResult is returned by the location service in response to query
 // requests.
-type QueryResult struct {
+type NearestResult struct {
 	// Error contains information about request failures.
 	Error *Error `json:"error,omitempty"`
 
@@ -104,7 +104,7 @@ type Target struct {
 }
 
 // Error describes an error condition that prevents the server from completing a
-// QueryResult.
+// NearestResult.
 type Error struct {
 	// RFC7807 Fields for "Problem Details".
 	Type     string `json:"type"`
@@ -114,7 +114,7 @@ type Error struct {
 	Instance string `json:"instance,omitempty"`
 }
 
-// NewError creates a new api Error for a QueryResult.
+// NewError creates a new api Error for a NearestResult.
 func NewError(typ, title string, status int) *Error {
 	return &Error{
 		Type:   typ,

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -114,7 +114,7 @@ func findLocation(rw http.ResponseWriter, headers http.Header) (string, string) 
 // TranslatedQuery uses the legacy mlab-ns service for liveness as a
 // transitional step in loading state directly.
 func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
-	result := v2.QueryResult{}
+	result := v2.NearestResult{}
 	experiment, service := getExperimentAndService(req.URL.Path)
 
 	// Set CORS policy to allow third-party websites to use returned resources.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -149,7 +149,7 @@ func TestClient_TranslatedQuery(t *testing.T) {
 			rtx.Must(err, "Failed to create request")
 			req.Header = tt.header
 
-			result := &v2.QueryResult{}
+			result := &v2.NearestResult{}
 			resp, err := proxy.UnmarshalResponse(req, result)
 			if err != nil {
 				t.Fatalf("Failed to get response from: %s %s", srv.URL, tt.path)


### PR DESCRIPTION
The previous type name was a legacy of the v2beta1 api which used the target resource name '/v2beta1/query'. However, that term is too generic. This change updates the result type to match the `/v2/nearest` resource name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/31)
<!-- Reviewable:end -->
