### PR TITLE
Add locate client API package

### DIFF
--- a/api/locate/client.go
+++ b/api/locate/client.go
@@ -1,0 +1,128 @@
+// Package locate implements a client for the Locate API v2.
+package locate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/m-lab/go/flagx"
+	v2 "github.com/m-lab/locate/api/v2"
+)
+
+// DefaultTimeout is the default request timeout.
+const DefaultTimeout = 15 * time.Second
+
+// ErrNoAvailableServers is returned when there are no available servers. A
+// background client should treat this error specially as described in the
+// specification of the ndt7 protocol.
+var ErrNoAvailableServers = errors.New("No available M-Lab servers")
+
+// ErrQueryFailed indicates a non-200 status code.
+var ErrQueryFailed = errors.New("locate API returned 4xx status code")
+
+// ErrRetry indicates an error that should be retried.
+var ErrRetry = errors.New("returned non-200 status code")
+
+// ErrServerError is a foo.
+var ErrServerError = errors.New("5xx status code")
+
+// ErrNoUserAgent is a foo.
+var ErrNoUserAgent = errors.New("client has no user-agent specified")
+
+// Client is an locate client.
+type Client struct {
+	// HTTPClient is the client that will perform the request. By default
+	// it is initialized to http.DefaultClient. You may override it for
+	// testing purpses and more generally whenever you are not satisfied
+	// with the behaviour of the default HTTP client.
+	HTTPClient *http.Client
+
+	// Timeout is the optional maximum amount of time we're willing to wait
+	// for mlabns to respond. This setting is initialized by NewClient to its
+	// default value, but you may override it.
+	Timeout time.Duration
+
+	// UserAgent is the mandatory user agent to be used. Also this
+	// field is initialized by NewClient.
+	UserAgent string
+
+	// BaseURL is the base url used to contact the Locate API.
+	BaseURL *url.URL
+}
+
+// baseURL is the default base URL.
+var baseURL = flagx.MustNewURL("https://locate.measurementlab.net/v2/nearest/")
+
+func init() {
+	flag.Var(&baseURL, "locate.url", "The base url for the Locate API")
+}
+
+// NewClient creates a new Client instance. The userAgent must not be empty.
+// NewClient sets the BaseURL to the -locate.url flag.
+func NewClient(userAgent string) *Client {
+	return &Client{
+		HTTPClient: http.DefaultClient,
+		Timeout:    DefaultTimeout,
+		UserAgent:  userAgent,
+		BaseURL:    baseURL.URL,
+	}
+}
+
+// Nearest returns a slice of nearby mlab servers. Returns an error on failure.
+func (c *Client) Nearest(ctx context.Context, service string) ([]v2.Target, error) {
+	var data []byte
+	var err error
+	var status int
+	reqURL := *c.BaseURL
+	reqURL.Path = path.Join(reqURL.Path, service)
+	data, status, err = c.get(ctx, reqURL.String())
+	if err != nil {
+		return nil, err
+	}
+	reply := &v2.NearestResult{}
+	err = json.Unmarshal(data, reply)
+	if err != nil {
+		// Cloud Endpoint errors have a different JSON structure.
+		// AppEngine 500 failures have no structure.
+		return nil, err
+	}
+	if status != http.StatusOK && reply.Error != nil {
+		// TODO: create a derived error using %w.
+		return nil, errors.New(reply.Error.Title + ": " + reply.Error.Detail)
+	}
+	if reply.Results == nil {
+		// Not an explicit error, and no results.
+		return nil, ErrNoAvailableServers
+	}
+	return reply.Results, nil
+}
+
+// get is an internal function used to perform the request.
+func (c *Client) get(ctx context.Context, URL string) ([]byte, int, error) {
+	reqctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqctx, http.MethodGet, URL, nil)
+	if err != nil {
+		// e.g. due to an invalid parameter.
+		return nil, 0, err
+	}
+	if c.UserAgent == "" {
+		// user agent is required.
+		return nil, 0, ErrNoUserAgent
+	}
+	req.Header.Set("User-Agent", c.UserAgent)
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	return b, resp.StatusCode, err
+}

--- a/api/locate/client.go
+++ b/api/locate/client.go
@@ -19,10 +19,10 @@ import (
 // clients should pause before scheduling a new request.
 var ErrNoAvailableServers = errors.New("No available M-Lab servers")
 
-// ErrNoUserAgent is a foo.
+// ErrNoUserAgent is returned when an empty user agent is used.
 var ErrNoUserAgent = errors.New("client has no user-agent specified")
 
-// Client is an locate client.
+// Client is a client for contacting the Locate API.
 type Client struct {
 	// HTTPClient performs all requests. Initialized to http.DefaultClient by
 	// NewClient. You may override it for alternate settings.

--- a/api/locate/client.go
+++ b/api/locate/client.go
@@ -22,7 +22,7 @@ var ErrNoAvailableServers = errors.New("No available M-Lab servers")
 // ErrNoUserAgent is returned when an empty user agent is used.
 var ErrNoUserAgent = errors.New("client has no user-agent specified")
 
-// Client is a client for contacting the Locate API.
+// Client is a client for contacting the Locate API. All fields are required.
 type Client struct {
 	// HTTPClient performs all requests. Initialized to http.DefaultClient by
 	// NewClient. You may override it for alternate settings.
@@ -33,6 +33,7 @@ type Client struct {
 	UserAgent string
 
 	// BaseURL is the base url used to contact the Locate API.
+	// NewClient sets the BaseURL to the -locate.url flag.
 	BaseURL *url.URL
 }
 
@@ -44,7 +45,6 @@ func init() {
 }
 
 // NewClient creates a new Client instance. The userAgent must not be empty.
-// NewClient sets the BaseURL to the -locate.url flag.
 func NewClient(userAgent string) *Client {
 	return &Client{
 		HTTPClient: http.DefaultClient,

--- a/api/locate/client.go
+++ b/api/locate/client.go
@@ -17,7 +17,7 @@ import (
 
 // ErrNoAvailableServers is returned when there are no available servers. Batch
 // clients should pause before scheduling a new request.
-var ErrNoAvailableServers = errors.New("No available M-Lab servers")
+var ErrNoAvailableServers = errors.New("no available M-Lab servers")
 
 // ErrNoUserAgent is returned when an empty user agent is used.
 var ErrNoUserAgent = errors.New("client has no user-agent specified")

--- a/api/locate/client_test.go
+++ b/api/locate/client_test.go
@@ -1,0 +1,150 @@
+// Package locate implements a client for the Locate API v2.
+package locate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/m-lab/go/rtx"
+	v2 "github.com/m-lab/locate/api/v2"
+)
+
+func mustParseURL(u string) *url.URL {
+	URL, err := url.Parse(u)
+	rtx.Must(err, "failed to parse url")
+	return URL
+}
+
+func TestClient_Nearest(t *testing.T) {
+	tests := []struct {
+		name        string
+		UserAgent   string
+		service     string
+		BaseURL     *url.URL
+		reply       *v2.NearestResult
+		status      int
+		wantErr     bool
+		closeServer bool
+		badJSON     bool
+	}{
+		/*
+		 */
+		{
+			name:      "success",
+			service:   "ndt/ndt7",
+			UserAgent: "unit-test",
+			status:    http.StatusOK,
+			reply: &v2.NearestResult{
+				Results: []v2.Target{
+					{
+						Machine: "mlab1-foo01.mlab-sandbox.measurement-lab.org",
+						URLs: map[string]string{
+							"ws:///ndt/v7/download": "fake-url"},
+					},
+				},
+			},
+		},
+		{
+			name:      "error-nil-results",
+			service:   "ndt/ndt7",
+			UserAgent: "unit-test",
+			status:    http.StatusOK,
+			reply:     &v2.NearestResult{},
+			wantErr:   true,
+		},
+		{
+			name:      "error-empty-user-agent",
+			service:   "ndt/ndt7",
+			UserAgent: "", // empty user agent.
+			reply:     &v2.NearestResult{},
+			wantErr:   true,
+		},
+		{
+			name:        "error-http-client-do-failure",
+			service:     "ndt/ndt7",
+			UserAgent:   "fake-user-agent",
+			reply:       &v2.NearestResult{},
+			wantErr:     true,
+			closeServer: true,
+		},
+		{
+			name:      "error-bad-json-response",
+			service:   "ndt/ndt7",
+			UserAgent: "fake-user-agent",
+			status:    http.StatusOK,
+			wantErr:   true,
+			badJSON:   true,
+		},
+		{
+			name:      "error-result-with-error",
+			service:   "ndt/ndt7",
+			UserAgent: "unit-test",
+			status:    http.StatusInternalServerError,
+			reply: &v2.NearestResult{
+				Error: &v2.Error{
+					Title:  "error",
+					Detail: "detail",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient(tt.UserAgent)
+			mux := http.NewServeMux()
+			path := "/v2/nearest/" + tt.service
+			mux.HandleFunc(path, func(rw http.ResponseWriter, req *http.Request) {
+				var b []byte
+				if tt.badJSON {
+					b = []byte("this-is-not-JSON{")
+				} else {
+					b, _ = json.Marshal(tt.reply)
+				}
+				rw.WriteHeader(tt.status)
+				rw.Write(b)
+			})
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+			if tt.closeServer {
+				srv.Close()
+			}
+
+			u, err := url.Parse(srv.URL)
+			u.Path = "/v2/nearest"
+			if tt.BaseURL != nil {
+				c.BaseURL = tt.BaseURL
+			} else {
+				c.BaseURL = u
+			}
+
+			ctx := context.Background()
+			got, err := c.Nearest(ctx, tt.service)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.Nearest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.reply != nil && !reflect.DeepEqual(got, tt.reply.Results) {
+				t.Errorf("Client.Nearest() = %v, want %v", got, tt.reply.Results)
+			}
+		})
+	}
+}
+
+// This test case is unreachable through the public interface.
+func TestClient_get(t *testing.T) {
+	t.Run("bad-url", func(t *testing.T) {
+		c := &Client{}
+		ctx := context.Background()
+		_, _, err := c.get(ctx, "://this-is-invalid")
+		if err == nil {
+			t.Errorf("Client.get() error nil, wantErr")
+			return
+		}
+	})
+}

--- a/api/locate/client_test.go
+++ b/api/locate/client_test.go
@@ -10,15 +10,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/m-lab/go/rtx"
 	v2 "github.com/m-lab/locate/api/v2"
 )
-
-func mustParseURL(u string) *url.URL {
-	URL, err := url.Parse(u)
-	rtx.Must(err, "failed to parse url")
-	return URL
-}
 
 func TestClient_Nearest(t *testing.T) {
 	tests := []struct {
@@ -32,8 +25,6 @@ func TestClient_Nearest(t *testing.T) {
 		closeServer bool
 		badJSON     bool
 	}{
-		/*
-		 */
 		{
 			name:      "success",
 			service:   "ndt/ndt7",

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/m-lab/go/host"
 	"github.com/m-lab/go/rtx"
 	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/locate/proxy"
 	"github.com/m-lab/locate/static"
 )
 
@@ -133,7 +134,11 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 	lat, lon := findLocation(rw, req.Header)
 	targets, err := c.Nearest(req.Context(), service, lat, lon)
 	if err != nil {
-		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if err == proxy.ErrNoContent {
+			status = http.StatusServiceUnavailable
+		}
+		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", status)
 		writeResult(rw, result.Error.Status, &result)
 		return
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -77,6 +77,14 @@ func TestClient_TranslatedQuery(t *testing.T) {
 			wantStatus: http.StatusInternalServerError,
 		},
 		{
+			name: "error-nearest-failure-no-content",
+			path: "ndt/ndt5",
+			locator: &fakeLocator{
+				err: proxy.ErrNoContent,
+			},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
 			name:   "error-corrupt-latlon",
 			path:   "ndt/ndt5",
 			signer: &fakeSigner{},


### PR DESCRIPTION
This change adds a simple Go client package for the Locate API v2.

This is a simple client because it does not handle the Locate API `v2.NextRequest` response nor does it easily support the priority requests using API keys. This change makes it possible to migrate the ndt5-client-go and ndt7-client-go utilities to use access tokens by default and preserve existing functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/32)
<!-- Reviewable:end -->
