### PR TITLE
Add locatetest package for unit tests

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -219,3 +219,12 @@ func TestClient_Heartbeat(t *testing.T) {
 		})
 	}
 }
+
+func TestNewClientDirect(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		c := NewClientDirect("fake-project", nil, nil)
+		if c == nil {
+			t.Error("got nil client!")
+		}
+	})
+}

--- a/locatetest/locatetest.go
+++ b/locatetest/locatetest.go
@@ -1,0 +1,60 @@
+package locatetest
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"gopkg.in/square/go-jose.v2/jwt"
+
+	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/locate/handler"
+)
+
+// Signer implements the Signer interface for unit tests.
+type Signer struct{}
+
+// Sign creates a fake signature using the given claims.
+func (s *Signer) Sign(cl jwt.Claims) (string, error) {
+	t := strings.Join([]string{
+		cl.Audience[0], cl.Subject, cl.Issuer, cl.Expiry.Time().Format(time.RFC3339),
+	}, "--")
+	return t, nil
+}
+
+// Locator is a fake Locator interface that returns the configured Servers or Err.
+type Locator struct {
+	Servers []string
+	Err     error
+}
+
+// Nearest returns the pre-configured Locator Servers or Err.
+func (l *Locator) Nearest(ctx context.Context, service, lat, lon string) ([]v2.Target, error) {
+	if l.Err != nil {
+		return nil, l.Err
+	}
+	t := make([]v2.Target, len(l.Servers))
+	for i := range l.Servers {
+		t[i].Machine = l.Servers[i]
+	}
+	return t, nil
+}
+
+// NewLocateServer creates an httptest.Server that can respond to Locate API v2
+// requests. Useful for unit testing.
+func NewLocateServer(loc *Locator) *httptest.Server {
+	// fake signer, fake locator.
+	s := &Signer{}
+	c := handler.NewClientDirect("fake-project", s, loc)
+
+	// USER APIs
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/nearest/", http.HandlerFunc(c.TranslatedQuery))
+
+	srv := httptest.NewServer(mux)
+	log.Println("Listening for INSECURE access requests on " + srv.URL)
+	return srv
+}

--- a/locatetest/locatetest_test.go
+++ b/locatetest/locatetest_test.go
@@ -1,0 +1,54 @@
+package locatetest
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/m-lab/go/testingx"
+	"github.com/m-lab/locate/api/locate"
+)
+
+func TestNewLocateServer(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		loc := &Locator{
+			Servers: []string{"127.0.0.1"},
+		}
+		srv := NewLocateServer(loc)
+
+		c := locate.NewClient("fake-user-agent")
+		u, err := url.Parse(srv.URL)
+		testingx.Must(t, err, "failed to parse locatetest url")
+		u.Path = "/v2/nearest/"
+		c.BaseURL = u
+
+		ctx := context.Background()
+		// NOTE: only known services (e.g. ndt/ndt7) are supported by the locate API.
+		targets, err := c.Nearest(ctx, "ndt/ndt7")
+		testingx.Must(t, err, "failed to get response from locatetest server")
+
+		if len(loc.Servers) != len(targets) {
+			t.Errorf("NewLocateServer() = got %d, want %d", len(targets), len(loc.Servers))
+		}
+	})
+	t.Run("error", func(t *testing.T) {
+		loc := &Locator{
+			Err: errors.New("fake error"),
+		}
+		srv := NewLocateServer(loc)
+
+		c := locate.NewClient("fake-user-agent")
+		u, err := url.Parse(srv.URL)
+		testingx.Must(t, err, "failed to parse locatetest url")
+		u.Path = "/v2/nearest/"
+		c.BaseURL = u
+
+		ctx := context.Background()
+		// NOTE: only known services (e.g. ndt/ndt7) are supported by the locate API.
+		targets, err := c.Nearest(ctx, "ndt/ndt7")
+		if err == nil {
+			t.Errorf("expected error, got %#v", targets)
+		}
+	})
+}


### PR DESCRIPTION
This change adds a new `locatetest` to create a locate API server for unit tests. Callers may provide a list of local servers (e.g.  created by https://github.com/m-lab/ndt-server/pull/319) that the locatetest server will return on request.

This should facilitate better lightweight unit tests for the ndt7-client.