### PR TITLE
Attempt to disable caching

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -134,6 +134,8 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 	// Set CORS policy to allow third-party websites to use returned resources.
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set("Access-Control-Allow-Origin", "*")
+	// Prevent caching of result.
+	rw.Header().Set("Cache-Control", "private, max-age=0, no-transform")
 
 	// Check whether the service is valid before all other steps to fail fast.
 	ports, ok := static.Configs[service]


### PR DESCRIPTION
This change explicitly sets a Cache-Control header to attempt to disable caching for some clients. Cached access tokens could lead to dysfunctional behavior such as multiple clients using the same tokens or clients receiving expired tokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/36)
<!-- Reviewable:end -->
