### PR TITLE
Log the client protocol used to contact the server

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -134,6 +134,8 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 	// Set CORS policy to allow third-party websites to use returned resources.
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set("Access-Control-Allow-Origin", "*")
+	// Prevent caching of result.
+	rw.Header().Set("Cache-Control", "private, max-age=0, no-transform")
 
 	// Check whether the service is valid before all other steps to fail fast.
 	ports, ok := static.Configs[service]

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -89,6 +89,7 @@ func findLocation(rw http.ResponseWriter, headers http.Header) (string, string) 
 		"CityLatLong": headers.Get("X-AppEngine-CityLatLong"),
 		"Country":     headers.Get("X-AppEngine-Country"),
 		"Region":      headers.Get("X-AppEngine-Region"),
+		"Proto":       headers.Get("X-Forwarded-Proto"),
 	}
 
 	// First, try the given lat/lon. Avoid invalid values like 0,0.


### PR DESCRIPTION
Suspecting that some Locate v2 responses are being cached, it would be helpful to log the protocol used to connect to the server, i.e. http or https. Caching can be performed by third parties only when http requests are used, or when middleboxes intercept https connections (mitm, which we would not detect using this logging).

If we see a high rate of http requests, then we could consider adding an option to disallow that request type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/37)
<!-- Reviewable:end -->
