### PR TITLE
Use a more explicit cache-control directive

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -136,7 +136,8 @@ func (c *Client) TranslatedQuery(rw http.ResponseWriter, req *http.Request) {
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Header().Set("Access-Control-Allow-Origin", "*")
 	// Prevent caching of result.
-	rw.Header().Set("Cache-Control", "private, max-age=0, no-transform")
+	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+	rw.Header().Set("Cache-Control", "no-store")
 
 	// Check whether the service is valid before all other steps to fail fast.
 	ports, ok := static.Configs[service]


### PR DESCRIPTION
The previous cache-control directive was take from an example we use on epoxy images and support files. However, after ~12 hrs using that with the locate v2 API, we do not see a reduction of token expired errors.

Researching more carefully, https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control the "no-store" directive is unambiguous about not storing the result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/38)
<!-- Reviewable:end -->
