### PR TITLE
Pass http parameters prefixed with "client_" to generated urls

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -153,7 +153,7 @@ func TestClient_TranslatedQuery(t *testing.T) {
 			srv := httptest.NewServer(mux)
 			defer srv.Close()
 
-			req, err := http.NewRequest(http.MethodGet, srv.URL+"/v2/nearest/"+tt.path, nil)
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/v2/nearest/"+tt.path+"?client_name=foo", nil)
 			rtx.Must(err, "Failed to create request")
 			req.Header = tt.header
 

--- a/handler/monitoring.go
+++ b/handler/monitoring.go
@@ -41,7 +41,7 @@ func (c *Client) Monitoring(rw http.ResponseWriter, req *http.Request) {
 	// Get monitoring subject access tokens for the given machine.
 	machine := cl.Subject
 	token := c.getAccessToken(machine, static.SubjectMonitoring)
-	urls := c.getURLs(ports, machine, experiment, token)
+	urls := c.getURLs(ports, machine, experiment, token, nil)
 	result.AccessToken = token
 	result.Target = &v2.Target{
 		// Monitoring results only include one target.


### PR DESCRIPTION
This change propagates some http parameters provided to the locate API request to the generated URLs so that they are passed to the measurement service.

Related to https://github.com/m-lab/ndt7-js/issues/4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/39)
<!-- Reviewable:end -->
