### PR TITLE
Add clientgeo package for appengine location

### DIFF
--- a/clientgeo/appengine.go
+++ b/clientgeo/appengine.go
@@ -1,0 +1,103 @@
+package clientgeo
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/m-lab/locate/static"
+)
+
+var (
+	// ErrBadLatLonFormat is returned with a lat,lon header is missing or corrupt.
+	ErrBadLatLonFormat = errors.New("lat,lon format was missing or corrupt")
+
+	// ErrNullLatLon is returned with a 0,0 lat/lon value is provided.
+	ErrNullLatLon = errors.New("lat,lon value was null: " + nullLatLon)
+
+	latlonMethod  = "appengine-latlong"
+	regionMethod  = "appengine-region"
+	countryMethod = "appengine-country"
+	noneMethod    = "appengine-none"
+	nullLatLon    = "0.000000,0.000000"
+)
+
+// NewAppEngineLocator thing.
+func NewAppEngineLocator() *AppEngineLocator {
+	return &AppEngineLocator{}
+}
+
+// AppEngineLocator thing.
+type AppEngineLocator struct{}
+
+// Locate finds a location for the given client request.
+func (sl *AppEngineLocator) Locate(req *http.Request) (*Location, error) {
+	headers := req.Header
+	fields := log.Fields{
+		"CityLatLong": headers.Get("X-AppEngine-CityLatLong"),
+		"Country":     headers.Get("X-AppEngine-Country"),
+		"Region":      headers.Get("X-AppEngine-Region"),
+		"Proto":       headers.Get("X-Forwarded-Proto"),
+		"Path":        req.URL.Path,
+	}
+
+	// First, try the given lat/lon. Avoid invalid values like 0,0.
+	latlon := headers.Get("X-AppEngine-CityLatLong")
+	loc, err := splitLatLon(latlon)
+	if err == nil {
+		log.WithFields(fields).Info(latlonMethod)
+		loc.Headers.Set("X-Locate-ClientLatLon", latlon)
+		loc.Headers.Set("X-Locate-ClientLatLon-Method", latlonMethod)
+		return loc, nil
+	}
+	// The next two fallback methods require the country, so check this next.
+	country := headers.Get("X-AppEngine-Country")
+	if country == "" || static.Countries[country] == "" {
+		// Without a valid country value, we can neither lookup the
+		// region nor country.
+		log.WithFields(fields).Info(noneMethod)
+		loc.Headers.Set("X-Locate-ClientLatLon-Method", noneMethod)
+		return loc, errors.New("X-Locate-ClientLatLon-Method: " + noneMethod)
+	}
+	// Second, country is valid, so try to lookup region.
+	region := strings.ToUpper(headers.Get("X-AppEngine-Region"))
+	if region != "" && static.Regions[country+"-"+region] != "" {
+		latlon = static.Regions[country+"-"+region]
+		log.WithFields(fields).Info(regionMethod)
+		loc, err := splitLatLon(latlon)
+		loc.Headers.Set("X-Locate-ClientLatLon", latlon)
+		loc.Headers.Set("X-Locate-ClientLatLon-Method", regionMethod)
+		return loc, err
+	}
+	// Third, region was not found, fallback to using the country.
+	latlon = static.Countries[country]
+	log.WithFields(fields).Info(countryMethod)
+	loc, err = splitLatLon(latlon)
+	loc.Headers.Set("X-Locate-ClientLatLon", latlon)
+	loc.Headers.Set("X-Locate-ClientLatLon-Method", countryMethod)
+	return loc, err
+}
+
+// Reload does nothing.
+func (sl *AppEngineLocator) Reload(ctx context.Context) {}
+
+// splitLatLon attempts to split the "<lat>,<lon>" string provided by AppEngine
+// into two fields. The return values preserve the original lat,lon order.
+func splitLatLon(latlon string) (*Location, error) {
+	loc := &Location{
+		// The empty header type is nil, so we set it.
+		Headers: http.Header{},
+	}
+	if latlon == nullLatLon {
+		return loc, ErrNullLatLon
+	}
+	fields := strings.Split(latlon, ",")
+	if len(fields) != 2 {
+		return loc, ErrBadLatLonFormat
+	}
+	loc.Latitude = fields[0]
+	loc.Longitude = fields[1]
+	return loc, nil
+}

--- a/clientgeo/appengine.go
+++ b/clientgeo/appengine.go
@@ -1,3 +1,5 @@
+// Package clientgeo supports interfaces to different data sources to help
+// identify client geo location for server selection.
 package clientgeo
 
 import (
@@ -24,15 +26,17 @@ var (
 	nullLatLon    = "0.000000,0.000000"
 )
 
-// NewAppEngineLocator thing.
+// NewAppEngineLocator creates a new AppEngineLocator.
 func NewAppEngineLocator() *AppEngineLocator {
 	return &AppEngineLocator{}
 }
 
-// AppEngineLocator thing.
+// AppEngineLocator finds a client location using AppEngine headers for lat/lon,
+// region, or country.
 type AppEngineLocator struct{}
 
-// Locate finds a location for the given client request.
+// Locate finds a location for the given client request using AppEngine headers.
+// If no location is found, an error is returned.
 func (sl *AppEngineLocator) Locate(req *http.Request) (*Location, error) {
 	headers := req.Header
 	fields := log.Fields{

--- a/clientgeo/appengine.go
+++ b/clientgeo/appengine.go
@@ -1,5 +1,3 @@
-// Package clientgeo supports interfaces to different data sources to help
-// identify client geo location for server selection.
 package clientgeo
 
 import (

--- a/clientgeo/appengine_test.go
+++ b/clientgeo/appengine_test.go
@@ -1,0 +1,108 @@
+// Package clientgeo supports interfaces to different data sources to help
+// identify client geo location for server selection.
+package clientgeo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestAppEngineLocator_Locate(t *testing.T) {
+	type args struct {
+	}
+	tests := []struct {
+		name       string
+		useHeaders map[string]string
+		want       *Location
+		wantErr    bool
+	}{
+		{
+			name: "success-using-latlong",
+			useHeaders: map[string]string{
+				"X-AppEngine-CityLatLong": "40.3,-70.4",
+			},
+			want: &Location{
+				Latitude:  "40.3",
+				Longitude: "-70.4",
+				Headers: http.Header{
+					"X-Locate-Clientlatlon":        []string{"40.3,-70.4"},
+					"X-Locate-Clientlatlon-Method": []string{"appengine-latlong"},
+				},
+			},
+		},
+		{
+			name:       "error-missing-country",
+			useHeaders: map[string]string{}, // none.
+			want: &Location{
+				Headers: http.Header{
+					"X-Locate-Clientlatlon-Method": []string{"appengine-none"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "success-using-region",
+			useHeaders: map[string]string{
+				"X-AppEngine-Country": "US",
+				"X-AppEngine-Region":  "NY",
+			},
+			want: &Location{
+				Latitude:  "43.19880000",
+				Longitude: "-75.3242000",
+				Headers: http.Header{
+					"X-Locate-Clientlatlon-Method": []string{"appengine-region"},
+					"X-Locate-Clientlatlon":        []string{"43.19880000,-75.3242000"},
+				},
+			},
+		},
+		{
+			name: "success-ignore-latlong-use-region",
+			useHeaders: map[string]string{
+				"X-AppEngine-CityLatLong": "0.000000,0.000000", // some IPs receive a "null" latlon, when region and country are valid.
+				"X-AppEngine-Country":     "US",
+				"X-AppEngine-Region":      "NY",
+			},
+			want: &Location{
+				Latitude:  "43.19880000",
+				Longitude: "-75.3242000",
+				Headers: http.Header{
+					"X-Locate-Clientlatlon-Method": []string{"appengine-region"},
+					"X-Locate-Clientlatlon":        []string{"43.19880000,-75.3242000"},
+				},
+			},
+		},
+		{
+			name: "success-using-country",
+			useHeaders: map[string]string{
+				"X-AppEngine-Country": "US",
+			},
+			want: &Location{
+				Latitude:  "37.09024",
+				Longitude: "-95.712891",
+				Headers: http.Header{
+					"X-Locate-Clientlatlon-Method": []string{"appengine-country"},
+					"X-Locate-Clientlatlon":        []string{"37.09024,-95.712891"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sl := NewAppEngineLocator()
+			req := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+			for key, value := range tt.useHeaders {
+				req.Header.Set(key, value)
+			}
+			got, err := sl.Locate(req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AppEngineLocator.Locate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AppEngineLocator.Locate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/clientgeo/appengine_test.go
+++ b/clientgeo/appengine_test.go
@@ -3,6 +3,7 @@
 package clientgeo
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -91,6 +92,7 @@ func TestAppEngineLocator_Locate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sl := NewAppEngineLocator()
+			sl.Reload(context.Background()) // completes code coverage.
 			req := httptest.NewRequest(http.MethodGet, "/whatever", nil)
 			for key, value := range tt.useHeaders {
 				req.Header.Set(key, value)

--- a/clientgeo/locator.go
+++ b/clientgeo/locator.go
@@ -1,0 +1,21 @@
+// Package clientgeo supports interfaces to different data sources to help
+// identify client geo location for server selection.
+package clientgeo
+
+import (
+	"context"
+	"net/http"
+)
+
+// Locator supports locating a client request and Reloading the underlying database.
+type Locator interface {
+	Locate(req *http.Request) (*Location, error)
+	Reload(context.Context)
+}
+
+// Location contains an estimated the latitude and longitude of a client IP.
+type Location struct {
+	Latitude  string
+	Longitude string
+	Headers   http.Header
+}

--- a/clientgeo/locator.go
+++ b/clientgeo/locator.go
@@ -19,3 +19,17 @@ type Location struct {
 	Longitude string
 	Headers   http.Header
 }
+
+// NullLocator always returns a client location of 0,0.
+type NullLocator struct{}
+
+// Locate returns the static 0,0 lat/lon location.
+func (f *NullLocator) Locate(req *http.Request) (*Location, error) {
+	return &Location{
+		Latitude:  "0.000000",
+		Longitude: "0.000000",
+	}, nil
+}
+
+// Reload does nothing.
+func (f *NullLocator) Reload(ctx context.Context) {}

--- a/clientgeo/locator_test.go
+++ b/clientgeo/locator_test.go
@@ -1,0 +1,23 @@
+// Package clientgeo supports interfaces to different data sources to help
+// identify client geo location for server selection.
+package clientgeo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNullLocator_Locate(t *testing.T) {
+	nl := &NullLocator{}
+	req := httptest.NewRequest(http.MethodGet, "/anyurl", nil)
+	nl.Reload(context.Background())
+	l, err := nl.Locate(req)
+	if err != nil {
+		t.Fatalf("NullLocator.Locate return an err; %v", err)
+	}
+	if l.Latitude != "0.000000" && l.Longitude != "0.000000" {
+		t.Fatalf("NullLocator.Location has wrong values; want: 0.000000,0.000000 got: %#v", l)
+	}
+}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -72,10 +72,14 @@ func TestClient_TranslatedQuery(t *testing.T) {
 		{
 			name: "error-nearest-failure",
 			path: "ndt/ndt5",
+			header: http.Header{
+				"X-AppEngine-CityLatLong": []string{"40.3,-70.4"},
+			},
+			wantLatLon: "40.3,-70.4", // Client receives lat/lon provided by AppEngine.
 			locator: &fakeLocator{
 				err: errors.New("Fake signer error"),
 			},
-			wantStatus: http.StatusServiceUnavailable,
+			wantStatus: http.StatusInternalServerError,
 		},
 		{
 			name: "error-nearest-failure-no-content",

--- a/handler/monitoring_test.go
+++ b/handler/monitoring_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/m-lab/access/controller"
 	"github.com/m-lab/go/rtx"
 	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/locate/clientgeo"
 	"github.com/m-lab/locate/static"
 )
 
@@ -89,7 +90,8 @@ func TestClient_Monitoring(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewClient("mlab-sandbox", tt.signer, tt.locator)
+			cl := clientgeo.NewAppEngineLocator()
+			c := NewClient("mlab-sandbox", tt.signer, tt.locator, cl)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/v2/monitoring/"+tt.path, nil)
 			req = req.Clone(controller.SetClaim(req.Context(), tt.claim))

--- a/locate.go
+++ b/locate.go
@@ -54,9 +54,9 @@ func main() {
 	// Load encrypted signer key from environment, using variable name derived from project.
 	signer, err := cfg.LoadSigner(mainCtx, client, locateSignerKey)
 	rtx.Must(err, "Failed to load signer key")
-	locator := proxy.MustNewLegacyLocator(legacyServer, platform)
-	finder := clientgeo.NewAppEngineLocator()
-	c := handler.NewClient(project, signer, locator, finder)
+	srvLocator := proxy.MustNewLegacyLocator(legacyServer, platform)
+	clLocator := clientgeo.NewAppEngineLocator()
+	c := handler.NewClient(project, signer, srvLocator, clLocator)
 
 	// MONITORING VERIFIER - for access tokens provided by monitoring.
 	verifier, err := cfg.LoadVerifier(mainCtx, client, monitoringVerifyKey...)

--- a/locate.go
+++ b/locate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/m-lab/go/flagx"
 	"github.com/m-lab/go/httpx"
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/locate/clientgeo"
 	"github.com/m-lab/locate/decrypt"
 	"github.com/m-lab/locate/handler"
 	"github.com/m-lab/locate/proxy"
@@ -54,7 +55,8 @@ func main() {
 	signer, err := cfg.LoadSigner(mainCtx, client, locateSignerKey)
 	rtx.Must(err, "Failed to load signer key")
 	locator := proxy.MustNewLegacyLocator(legacyServer, platform)
-	c := handler.NewClient(project, signer, locator)
+	finder := clientgeo.NewAppEngineLocator()
+	c := handler.NewClient(project, signer, locator, finder)
 
 	// MONITORING VERIFIER - for access tokens provided by monitoring.
 	verifier, err := cfg.LoadVerifier(mainCtx, client, monitoringVerifyKey...)

--- a/locatetest/locatetest.go
+++ b/locatetest/locatetest.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 
 	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/locate/clientgeo"
 	"github.com/m-lab/locate/handler"
 )
 
@@ -48,7 +49,7 @@ func (l *Locator) Nearest(ctx context.Context, service, lat, lon string) ([]v2.T
 func NewLocateServer(loc *Locator) *httptest.Server {
 	// fake signer, fake locator.
 	s := &Signer{}
-	c := handler.NewClientDirect("fake-project", s, loc)
+	c := handler.NewClientDirect("fake-project", s, loc, &clientgeo.NullLocator{})
 
 	// USER APIs
 	mux := http.NewServeMux()


### PR DESCRIPTION
This change moves the "findLocation" logic from the http handler to a new `clientgeo` package. We want to add additional methods of looking up the client location. This is the first step to making an general interface for that operation.

This change better distinguishes the ServiceUnavailable and InternalServiceError cases. Unit tests are updated accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/42)
<!-- Reviewable:end -->
