### PR TITLE
Add support for user-provided location hints

### DIFF
--- a/clientgeo/user.go
+++ b/clientgeo/user.go
@@ -48,13 +48,13 @@ func (u *UserLocator) Locate(req *http.Request) (*Location, error) {
 		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-latlon")
 		return loc, nil
 	}
-	if ll := static.Regions[req.URL.Query().Get("region")]; ll != "" {
+	if ll, ok := static.Regions[req.URL.Query().Get("region")]; ok {
 		loc, err := splitLatLon(ll)
 		loc.Headers.Set("X-Locate-ClientLatLon", ll)
 		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-region")
 		return loc, err
 	}
-	if ll := static.Countries[req.URL.Query().Get("country")]; ll != "" {
+	if ll, ok := static.Countries[req.URL.Query().Get("country")]; ok {
 		loc, err := splitLatLon(ll)
 		loc.Headers.Set("X-Locate-ClientLatLon", ll)
 		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-country")

--- a/clientgeo/user.go
+++ b/clientgeo/user.go
@@ -15,8 +15,8 @@ type UserLocator struct{}
 
 // Error values returned by Locate.
 var (
-	ErrNoUserParameters     = errors.New("no user location parameters provided")
-	ErrUsableUserParameters = errors.New("user provided location parameters were unusable")
+	ErrNoUserParameters       = errors.New("no user location parameters provided")
+	ErrUnusableUserParameters = errors.New("user provided location parameters were unusable")
 )
 
 // NewUserLocator creates a new UserLocator.
@@ -35,7 +35,7 @@ func (u *UserLocator) Locate(req *http.Request) (*Location, error) {
 		if errLat != nil || errLon != nil ||
 			math.IsNaN(flat) || math.IsInf(flat, 0) ||
 			math.IsNaN(flon) || math.IsInf(flon, 0) {
-			return nil, ErrUsableUserParameters
+			return nil, ErrUnusableUserParameters
 		}
 		loc := &Location{
 			Latitude:  lat,

--- a/clientgeo/user.go
+++ b/clientgeo/user.go
@@ -1,0 +1,49 @@
+package clientgeo
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/m-lab/locate/static"
+)
+
+type UserLocator struct{}
+
+var ErrNoUserParameters = errors.New("no user location parameters provided")
+
+func NewUserLocator() *UserLocator {
+	return &UserLocator{}
+}
+
+// Locate looks for user-provided parameters to specify the client location.
+func (u *UserLocator) Locate(req *http.Request) (*Location, error) {
+	lat := req.URL.Query().Get("lat")
+	lon := req.URL.Query().Get("lon")
+	if lat != "" && lon != "" {
+		loc := &Location{
+			Latitude:  lat,
+			Longitude: lon,
+			Headers:   http.Header{},
+		}
+		loc.Headers.Set("X-Locate-ClientLatLon", lat+","+lon)
+		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-latlon")
+		return loc, nil
+	}
+	if ll := static.Regions[req.URL.Query().Get("region")]; ll != "" {
+		loc, err := splitLatLon(ll)
+		loc.Headers.Set("X-Locate-ClientLatLon", ll)
+		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-region")
+		return loc, err
+	}
+	if ll := static.Countries[req.URL.Query().Get("country")]; ll != "" {
+		loc, err := splitLatLon(ll)
+		loc.Headers.Set("X-Locate-ClientLatLon", ll)
+		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-country")
+		return loc, err
+	}
+	return nil, ErrNoUserParameters
+}
+
+// Reload does nothing.
+func (u *UserLocator) Reload(ctx context.Context) {}

--- a/clientgeo/user.go
+++ b/clientgeo/user.go
@@ -34,7 +34,9 @@ func (u *UserLocator) Locate(req *http.Request) (*Location, error) {
 		flon, errLon := strconv.ParseFloat(lon, 64)
 		if errLat != nil || errLon != nil ||
 			math.IsNaN(flat) || math.IsInf(flat, 0) ||
-			math.IsNaN(flon) || math.IsInf(flon, 0) {
+			math.IsNaN(flon) || math.IsInf(flon, 0) ||
+			-90 > flat || flat > 90 ||
+			-180 > flon || flon > 180 {
 			return nil, ErrUnusableUserParameters
 		}
 		loc := &Location{

--- a/clientgeo/user_test.go
+++ b/clientgeo/user_test.go
@@ -60,7 +60,7 @@ func TestUserLocator_Locate(t *testing.T) {
 			},
 		},
 		{
-			name: "error-unparsable-latitude-parameters",
+			name: "error-unusable-latitude-parameters",
 			vals: url.Values{
 				"lat": []string{"xyz.000"},
 				"lon": []string{"34"},
@@ -68,7 +68,7 @@ func TestUserLocator_Locate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "error-unparsable-longitude-parameters",
+			name: "error-unusable-longitude-parameters",
 			vals: url.Values{
 				"lat": []string{"12"},
 				"lon": []string{"xyz.000"},
@@ -76,7 +76,7 @@ func TestUserLocator_Locate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "error-unparsable-nan",
+			name: "error-unusable-nan",
 			vals: url.Values{
 				"lat": []string{"NaN"},
 				"lon": []string{"NaN"},
@@ -84,7 +84,7 @@ func TestUserLocator_Locate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "error-unparsable-inf",
+			name: "error-unusable-inf",
 			vals: url.Values{
 				"lat": []string{"Inf"},
 				"lon": []string{"Inf"},

--- a/clientgeo/user_test.go
+++ b/clientgeo/user_test.go
@@ -92,6 +92,22 @@ func TestUserLocator_Locate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "error-unusable-lat-too-big",
+			vals: url.Values{
+				"lat": []string{"91"},
+				"lon": []string{"0"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-unusable-lon-too-big",
+			vals: url.Values{
+				"lat": []string{"0"},
+				"lon": []string{"181"},
+			},
+			wantErr: true,
+		},
+		{
 			name:    "error-no-parameters",
 			wantErr: true,
 		},

--- a/clientgeo/user_test.go
+++ b/clientgeo/user_test.go
@@ -60,6 +60,38 @@ func TestUserLocator_Locate(t *testing.T) {
 			},
 		},
 		{
+			name: "error-unparsable-latitude-parameters",
+			vals: url.Values{
+				"lat": []string{"xyz.000"},
+				"lon": []string{"34"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-unparsable-longitude-parameters",
+			vals: url.Values{
+				"lat": []string{"12"},
+				"lon": []string{"xyz.000"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-unparsable-nan",
+			vals: url.Values{
+				"lat": []string{"NaN"},
+				"lon": []string{"NaN"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-unparsable-inf",
+			vals: url.Values{
+				"lat": []string{"Inf"},
+				"lon": []string{"Inf"},
+			},
+			wantErr: true,
+		},
+		{
 			name:    "error-no-parameters",
 			wantErr: true,
 		},

--- a/clientgeo/user_test.go
+++ b/clientgeo/user_test.go
@@ -1,0 +1,83 @@
+package clientgeo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestUserLocator_Locate(t *testing.T) {
+	tests := []struct {
+		name    string
+		vals    url.Values
+		want    *Location
+		wantErr bool
+	}{
+		{
+			name: "success-user-latlon",
+			want: &Location{
+				Latitude:  "12",
+				Longitude: "34",
+				Headers: http.Header{
+					"X-Locate-Clientlatlon":        []string{"12,34"},
+					"X-Locate-Clientlatlon-Method": []string{"user-latlon"},
+				},
+			},
+			vals: url.Values{
+				"lat": []string{"12"},
+				"lon": []string{"34"},
+			},
+		},
+		{
+			name: "success-user-region",
+			want: &Location{
+				Latitude:  "43.19880000",
+				Longitude: "-75.3242000",
+				Headers: http.Header{
+					"X-Locate-Clientlatlon":        []string{"43.19880000,-75.3242000"},
+					"X-Locate-Clientlatlon-Method": []string{"user-region"},
+				},
+			},
+			vals: url.Values{
+				"region": []string{"US-NY"},
+			},
+		},
+		{
+			name: "success-user-country",
+			want: &Location{
+				Latitude:  "37.09024",
+				Longitude: "-95.712891",
+				Headers: http.Header{
+					"X-Locate-Clientlatlon":        []string{"37.09024,-95.712891"},
+					"X-Locate-Clientlatlon-Method": []string{"user-country"},
+				},
+			},
+			vals: url.Values{
+				"country": []string{"US"},
+			},
+		},
+		{
+			name:    "error-no-parameters",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := NewUserLocator()
+			req := httptest.NewRequest(http.MethodGet, "/v2/nearest", nil)
+			req.URL.RawQuery = tt.vals.Encode()
+			got, err := u.Locate(req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UserLocator.Locate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UserLocator.Locate() = %v, want %v", got, tt.want)
+			}
+			u.Reload(context.Background())
+		})
+	}
+}

--- a/locate.go
+++ b/locate.go
@@ -65,7 +65,7 @@ func main() {
 	rtx.Must(err, "Failed to load signer key")
 	srvLocator := proxy.MustNewLegacyLocator(legacyServer, platform)
 
-	locators := clientgeo.MultiLocator{}
+	locators := clientgeo.MultiLocator{clientgeo.NewUserLocator()}
 	if locatorAE {
 		aeLocator := clientgeo.NewAppEngineLocator()
 		locators = append(locators, aeLocator)


### PR DESCRIPTION
This change uses the Locator interface to add support for user-provided location hints using `country=` or `region=` http parameters. This Locator is registered first, so takes precedence over both the AppEngine and Maxmind Locators.

Regardless of a user's actual location when they make the request, the user-provided location parameters are considered first. For example, this would allow a user in US-NY to get access tokens and run a measurement to servers in DE.

The set of country and region codes recognized are the same as those defined in https://github.com/m-lab/locate/tree/master/static.

Example usage would be:

* https://locate.measurementlab.net/v2/nearest/ndt/ndt7?country=DE  (Germany)
* https://locate.measurementlab.net/v2/nearest/ndt/ndt7?region=DE-BE (Berlin specifically)

Part of https://github.com/m-lab/locate/issues/40

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/44)
<!-- Reviewable:end -->
