### PR TITLE
Use constant names for X-Locate-Client* headers

### DIFF
--- a/clientgeo/appengine.go
+++ b/clientgeo/appengine.go
@@ -50,8 +50,8 @@ func (sl *AppEngineLocator) Locate(req *http.Request) (*Location, error) {
 	loc, err := splitLatLon(latlon)
 	if err == nil {
 		log.WithFields(fields).Info(latlonMethod)
-		loc.Headers.Set("X-Locate-ClientLatLon", latlon)
-		loc.Headers.Set("X-Locate-ClientLatLon-Method", latlonMethod)
+		loc.Headers.Set(hLocateClientlatlon, latlon)
+		loc.Headers.Set(hLocateClientlatlonMethod, latlonMethod)
 		return loc, nil
 	}
 	// The next two fallback methods require the country, so check this next.
@@ -60,8 +60,8 @@ func (sl *AppEngineLocator) Locate(req *http.Request) (*Location, error) {
 		// Without a valid country value, we can neither lookup the
 		// region nor country.
 		log.WithFields(fields).Info(noneMethod)
-		loc.Headers.Set("X-Locate-ClientLatLon-Method", noneMethod)
-		return loc, errors.New("X-Locate-ClientLatLon-Method: " + noneMethod)
+		loc.Headers.Set(hLocateClientlatlonMethod, noneMethod)
+		return loc, errors.New(hLocateClientlatlonMethod + ": " + noneMethod)
 	}
 	// Second, country is valid, so try to lookup region.
 	region := strings.ToUpper(headers.Get("X-AppEngine-Region"))
@@ -69,16 +69,16 @@ func (sl *AppEngineLocator) Locate(req *http.Request) (*Location, error) {
 		latlon = static.Regions[country+"-"+region]
 		log.WithFields(fields).Info(regionMethod)
 		loc, err := splitLatLon(latlon)
-		loc.Headers.Set("X-Locate-ClientLatLon", latlon)
-		loc.Headers.Set("X-Locate-ClientLatLon-Method", regionMethod)
+		loc.Headers.Set(hLocateClientlatlon, latlon)
+		loc.Headers.Set(hLocateClientlatlonMethod, regionMethod)
 		return loc, err
 	}
 	// Third, region was not found, fallback to using the country.
 	latlon = static.Countries[country]
 	log.WithFields(fields).Info(countryMethod)
 	loc, err = splitLatLon(latlon)
-	loc.Headers.Set("X-Locate-ClientLatLon", latlon)
-	loc.Headers.Set("X-Locate-ClientLatLon-Method", countryMethod)
+	loc.Headers.Set(hLocateClientlatlon, latlon)
+	loc.Headers.Set(hLocateClientlatlonMethod, countryMethod)
 	return loc, err
 }
 

--- a/clientgeo/appengine_test.go
+++ b/clientgeo/appengine_test.go
@@ -28,8 +28,8 @@ func TestAppEngineLocator_Locate(t *testing.T) {
 				Latitude:  "40.3",
 				Longitude: "-70.4",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon":        []string{"40.3,-70.4"},
-					"X-Locate-Clientlatlon-Method": []string{"appengine-latlong"},
+					hLocateClientlatlon:       []string{"40.3,-70.4"},
+					hLocateClientlatlonMethod: []string{"appengine-latlong"},
 				},
 			},
 		},
@@ -38,7 +38,7 @@ func TestAppEngineLocator_Locate(t *testing.T) {
 			useHeaders: map[string]string{}, // none.
 			want: &Location{
 				Headers: http.Header{
-					"X-Locate-Clientlatlon-Method": []string{"appengine-none"},
+					hLocateClientlatlonMethod: []string{"appengine-none"},
 				},
 			},
 			wantErr: true,
@@ -53,8 +53,8 @@ func TestAppEngineLocator_Locate(t *testing.T) {
 				Latitude:  "43.19880000",
 				Longitude: "-75.3242000",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon-Method": []string{"appengine-region"},
-					"X-Locate-Clientlatlon":        []string{"43.19880000,-75.3242000"},
+					hLocateClientlatlonMethod: []string{"appengine-region"},
+					hLocateClientlatlon:       []string{"43.19880000,-75.3242000"},
 				},
 			},
 		},
@@ -69,8 +69,8 @@ func TestAppEngineLocator_Locate(t *testing.T) {
 				Latitude:  "43.19880000",
 				Longitude: "-75.3242000",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon-Method": []string{"appengine-region"},
-					"X-Locate-Clientlatlon":        []string{"43.19880000,-75.3242000"},
+					hLocateClientlatlonMethod: []string{"appengine-region"},
+					hLocateClientlatlon:       []string{"43.19880000,-75.3242000"},
 				},
 			},
 		},
@@ -83,8 +83,8 @@ func TestAppEngineLocator_Locate(t *testing.T) {
 				Latitude:  "37.09024",
 				Longitude: "-95.712891",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon-Method": []string{"appengine-country"},
-					"X-Locate-Clientlatlon":        []string{"37.09024,-95.712891"},
+					hLocateClientlatlonMethod: []string{"appengine-country"},
+					hLocateClientlatlon:       []string{"37.09024,-95.712891"},
 				},
 			},
 		},

--- a/clientgeo/locator.go
+++ b/clientgeo/locator.go
@@ -9,6 +9,12 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+// Constants defining the X-Locate-* header names produced by Locators.
+const (
+	hLocateClientlatlon       = "X-Locate-Clientlatlon"
+	hLocateClientlatlonMethod = "X-Locate-Clientlatlon-Method"
+)
+
 // Locator supports locating a client request and Reloading the underlying database.
 type Locator interface {
 	Locate(req *http.Request) (*Location, error)

--- a/clientgeo/maxmind.go
+++ b/clientgeo/maxmind.go
@@ -75,13 +75,11 @@ func (mml *MaxmindLocator) Locate(req *http.Request) (*Location, error) {
 	tmp := &Location{
 		Latitude:  lat,
 		Longitude: lon,
-		Headers:   http.Header{
-			//"X-Locate-ClientLatLon":        []string{lat + "," + lon},
-			//"X-Locate-ClientLatLon-Method": []string{"maxmind-remoteip"},
+		Headers: http.Header{
+			hLocateClientlatlon:       []string{lat + "," + lon},
+			hLocateClientlatlonMethod: []string{"maxmind-remoteip"},
 		},
 	}
-	tmp.Headers.Set("X-Locate-ClientLatLon", lat+","+lon)
-	tmp.Headers.Set("X-Locate-ClientLatLon-Method", "maxmind-remoteip")
 	return tmp, nil
 }
 

--- a/clientgeo/maxmind.go
+++ b/clientgeo/maxmind.go
@@ -75,11 +75,13 @@ func (mml *MaxmindLocator) Locate(req *http.Request) (*Location, error) {
 	tmp := &Location{
 		Latitude:  lat,
 		Longitude: lon,
-		Headers: http.Header{
-			"X-Locate-ClientLatLon":        []string{lat + "," + lon},
-			"X-Locate-ClientLatLon-Method": []string{"maxmind-remoteip"},
+		Headers:   http.Header{
+			//"X-Locate-ClientLatLon":        []string{lat + "," + lon},
+			//"X-Locate-ClientLatLon-Method": []string{"maxmind-remoteip"},
 		},
 	}
+	tmp.Headers.Set("X-Locate-ClientLatLon", lat+","+lon)
+	tmp.Headers.Set("X-Locate-ClientLatLon-Method", "maxmind-remoteip")
 	return tmp, nil
 }
 

--- a/clientgeo/maxmind_test.go
+++ b/clientgeo/maxmind_test.go
@@ -39,8 +39,8 @@ func TestNewMaxmindLocator(t *testing.T) {
 				Latitude:  "51.750000",
 				Longitude: "-1.250000",
 				Headers: http.Header{
-					"X-Locate-ClientLatLon":        []string{"51.750000,-1.250000"},
-					"X-Locate-ClientLatLon-Method": []string{"maxmind-remoteip"},
+					"X-Locate-Clientlatlon":        []string{"51.750000,-1.250000"},
+					"X-Locate-Clientlatlon-Method": []string{"maxmind-remoteip"},
 				},
 			},
 			filename: "file:./testdata/fake.tar.gz",
@@ -52,8 +52,8 @@ func TestNewMaxmindLocator(t *testing.T) {
 				Latitude:  "51.750000",
 				Longitude: "-1.250000",
 				Headers: http.Header{
-					"X-Locate-ClientLatLon":        []string{"51.750000,-1.250000"},
-					"X-Locate-ClientLatLon-Method": []string{"maxmind-remoteip"},
+					"X-Locate-Clientlatlon":        []string{"51.750000,-1.250000"},
+					"X-Locate-Clientlatlon-Method": []string{"maxmind-remoteip"},
 				},
 			},
 			filename: "file:./testdata/fake.tar.gz",

--- a/clientgeo/maxmind_test.go
+++ b/clientgeo/maxmind_test.go
@@ -39,8 +39,8 @@ func TestNewMaxmindLocator(t *testing.T) {
 				Latitude:  "51.750000",
 				Longitude: "-1.250000",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon":        []string{"51.750000,-1.250000"},
-					"X-Locate-Clientlatlon-Method": []string{"maxmind-remoteip"},
+					hLocateClientlatlon:       []string{"51.750000,-1.250000"},
+					hLocateClientlatlonMethod: []string{"maxmind-remoteip"},
 				},
 			},
 			filename: "file:./testdata/fake.tar.gz",
@@ -52,8 +52,8 @@ func TestNewMaxmindLocator(t *testing.T) {
 				Latitude:  "51.750000",
 				Longitude: "-1.250000",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon":        []string{"51.750000,-1.250000"},
-					"X-Locate-Clientlatlon-Method": []string{"maxmind-remoteip"},
+					hLocateClientlatlon:       []string{"51.750000,-1.250000"},
+					hLocateClientlatlonMethod: []string{"maxmind-remoteip"},
 				},
 			},
 			filename: "file:./testdata/fake.tar.gz",

--- a/clientgeo/user.go
+++ b/clientgeo/user.go
@@ -44,20 +44,20 @@ func (u *UserLocator) Locate(req *http.Request) (*Location, error) {
 			Longitude: lon,
 			Headers:   http.Header{},
 		}
-		loc.Headers.Set("X-Locate-ClientLatLon", lat+","+lon)
-		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-latlon")
+		loc.Headers.Set(hLocateClientlatlon, lat+","+lon)
+		loc.Headers.Set(hLocateClientlatlonMethod, "user-latlon")
 		return loc, nil
 	}
 	if ll, ok := static.Regions[req.URL.Query().Get("region")]; ok {
 		loc, err := splitLatLon(ll)
-		loc.Headers.Set("X-Locate-ClientLatLon", ll)
-		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-region")
+		loc.Headers.Set(hLocateClientlatlon, ll)
+		loc.Headers.Set(hLocateClientlatlonMethod, "user-region")
 		return loc, err
 	}
 	if ll, ok := static.Countries[req.URL.Query().Get("country")]; ok {
 		loc, err := splitLatLon(ll)
-		loc.Headers.Set("X-Locate-ClientLatLon", ll)
-		loc.Headers.Set("X-Locate-ClientLatLon-Method", "user-country")
+		loc.Headers.Set(hLocateClientlatlon, ll)
+		loc.Headers.Set(hLocateClientlatlonMethod, "user-country")
 		return loc, err
 	}
 	return nil, ErrNoUserParameters

--- a/clientgeo/user_test.go
+++ b/clientgeo/user_test.go
@@ -22,8 +22,8 @@ func TestUserLocator_Locate(t *testing.T) {
 				Latitude:  "12",
 				Longitude: "34",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon":        []string{"12,34"},
-					"X-Locate-Clientlatlon-Method": []string{"user-latlon"},
+					hLocateClientlatlon:       []string{"12,34"},
+					hLocateClientlatlonMethod: []string{"user-latlon"},
 				},
 			},
 			vals: url.Values{
@@ -37,8 +37,8 @@ func TestUserLocator_Locate(t *testing.T) {
 				Latitude:  "43.19880000",
 				Longitude: "-75.3242000",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon":        []string{"43.19880000,-75.3242000"},
-					"X-Locate-Clientlatlon-Method": []string{"user-region"},
+					hLocateClientlatlon:       []string{"43.19880000,-75.3242000"},
+					hLocateClientlatlonMethod: []string{"user-region"},
 				},
 			},
 			vals: url.Values{
@@ -51,8 +51,8 @@ func TestUserLocator_Locate(t *testing.T) {
 				Latitude:  "37.09024",
 				Longitude: "-95.712891",
 				Headers: http.Header{
-					"X-Locate-Clientlatlon":        []string{"37.09024,-95.712891"},
-					"X-Locate-Clientlatlon-Method": []string{"user-country"},
+					hLocateClientlatlon:       []string{"37.09024,-95.712891"},
+					hLocateClientlatlonMethod: []string{"user-country"},
 				},
 			},
 			vals: url.Values{

--- a/locate.go
+++ b/locate.go
@@ -66,15 +66,15 @@ func main() {
 	srvLocator := proxy.MustNewLegacyLocator(legacyServer, platform)
 
 	locators := clientgeo.MultiLocator{clientgeo.NewUserLocator()}
+	if locatorAE {
+		aeLocator := clientgeo.NewAppEngineLocator()
+		locators = append(locators, aeLocator)
+	}
 	if locatorMM {
 		mm, err := content.FromURL(mainCtx, maxmind.URL)
 		rtx.Must(err, "failed to load maxmindurl: %s", maxmind.URL)
 		mmLocator := clientgeo.NewMaxmindLocator(mainCtx, mm)
 		locators = append(locators, mmLocator)
-	}
-	if locatorAE {
-		aeLocator := clientgeo.NewAppEngineLocator()
-		locators = append(locators, aeLocator)
 	}
 	c := handler.NewClient(project, signer, srvLocator, locators)
 

--- a/locate.go
+++ b/locate.go
@@ -66,15 +66,15 @@ func main() {
 	srvLocator := proxy.MustNewLegacyLocator(legacyServer, platform)
 
 	locators := clientgeo.MultiLocator{clientgeo.NewUserLocator()}
-	if locatorAE {
-		aeLocator := clientgeo.NewAppEngineLocator()
-		locators = append(locators, aeLocator)
-	}
 	if locatorMM {
 		mm, err := content.FromURL(mainCtx, maxmind.URL)
 		rtx.Must(err, "failed to load maxmindurl: %s", maxmind.URL)
 		mmLocator := clientgeo.NewMaxmindLocator(mainCtx, mm)
 		locators = append(locators, mmLocator)
+	}
+	if locatorAE {
+		aeLocator := clientgeo.NewAppEngineLocator()
+		locators = append(locators, aeLocator)
 	}
 	c := handler.NewClient(project, signer, srvLocator, locators)
 


### PR DESCRIPTION
This change replaces all instances of "X-Locate-Client*" headers with constant names to fix a bug where the maxmind headers were not returned correctly.

This bug was caused by the inline definition of `http.Headers` with non-canonical header key names, https://github.com/m-lab/locate/blob/e2fd31484cdb6603f4209cfe294b23f965d4c069/clientgeo/maxmind.go#L78-L81

combined with the header copy loop using `http.Header.Get` and `http.Header.Set` methods, which normalize key names strictly using `textproto.CanonicalMIMEHeaderKey`. https://github.com/m-lab/locate/blob/e2fd31484cdb6603f4209cfe294b23f965d4c069/handler/handler.go#L120-L122

So, the copy loop used canonical names while the underlying map had non-canonical keys. As a result, they were unnameable.

This bug does not effect the maxmind location lookup, only the reporting of location&method to the caller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/45)
<!-- Reviewable:end -->
