### PR TITLE
Add location details to Usage.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -19,7 +19,7 @@ operations and describe currently supported queries in more detail.
 #### When best means "geographically close"
 
 GCP automatically adds client latitude and longitude to incoming [HTTP
-request headers][headers]. The locate API uses this location to search for
+request headers][headers]. For additional information about how GCP identifies a client's location, please see the section below, **How GCP identifies client location**. The locate API uses this location to search for
 nearby M-Lab servers that satisfy the client query.
 
 [headers]: https://cloud.google.com/load-balancing/docs/user-defined-request-headers#how_user-defined_request_headers_work
@@ -115,3 +115,61 @@ users.
 
 > PLANNED(v2): the Locate API `NextRequest` will provide clients with a wait
 time before trying again.
+
+## How GCP Identifies Client Location
+
+As mentioned above, the Locate service uses GCP to determine a client's location and direct the client to the nearest M-Lab server. Using the Locate service with no additional parameters will provide the Latitude & Longitude from Appengine. For example, see the query and response below:
+
+```
+$ curl --head 'http://locate.measurementlab.net/v2/nearest/ndt/ndt7'
+
+HTTP/1.1 200 OK
+Date: Wed, 20 Jan 2021 16:05:12 GMT
+Content-Type: application/json
+Vary: Accept-Encoding
+Access-Control-Allow-Origin: *
+Cache-Control: no-store
+X-Locate-Clientlatlon: 40.914821,-74.383763
+X-Locate-Clientlatlon-Method: appengine-latlong
+Via: 1.1 google
+Transfer-Encoding: chunked
+```
+
+In this case, the Locate service used the Appengine provided latitude and longitude values, derived from the [Appengine headers](headers), `X-Appengine-Country` and `X-Appengine-Region`.
+
+[headers]: https://cloud.google.com/appengine/docs/flexible/go/reference/request-headers
+
+A client may also use Locate service and specify a `country` or `region` parameter to select a server nearest to that country or region. For example see the queries and responses below:
+
+```
+$ curl --head 'http://locate.measurementlab.net/v2/nearest/ndt/ndt7?country=IN
+
+HTTP/1.1 200 OK
+Date: Wed, 20 Jan 2021 18:26:05 GMT
+Content-Type: application/json
+Vary: Accept-Encoding
+Access-Control-Allow-Origin: *
+Cache-Control: no-store
+X-Locate-Clientlatlon: 20.593684,78.96288
+X-Locate-Clientlatlon-Method: user-country
+Via: 1.1 google
+Transfer-Encoding: chunked
+
+$ curl --head 'http://locate.measurementlab.net/v2/nearest/ndt/ndt7?region=US-IL'
+
+HTTP/1.1 200 OK
+Date: Wed, 20 Jan 2021 18:22:54 GMT
+Content-Type: application/json
+Vary: Accept-Encoding
+Access-Control-Allow-Origin: *
+Cache-Control: no-store
+X-Locate-Clientlatlon: 39.94600000,-89.1991000
+X-Locate-Clientlatlon-Method: user-region
+Via: 1.1 google
+Transfer-Encoding: chunked
+```
+
+Countries are specified using the [ISO 3166-1 alpha 2 country code](iso1) (`country=IN`) or the [ISO 3166-2 region code](iso2) (`region=US-IL`).
+
+[iso1]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+[iso2]: https://en.wikipedia.org/wiki/ISO_3166-2

--- a/USAGE.md
+++ b/USAGE.md
@@ -18,9 +18,11 @@ operations and describe currently supported queries in more detail.
 
 #### When best means "geographically close"
 
-GCP automatically adds client latitude and longitude to incoming [HTTP
-request headers][headers]. For additional information about how GCP identifies a client's location, please see the section below, **How GCP identifies client location**. The locate API uses this location to search for
-nearby M-Lab servers that satisfy the client query.
+GCP automatically adds client latitude and longitude to incoming [HTTP request 
+headers][headers]. The locate API uses this location to search fornearby M-Lab 
+servers that satisfy the client query. For additional information about how 
+GCP identifies a client's location, please see the section below, [How GCP 
+identifies client location](#how-gcp-identifies-client-location).
 
 [headers]: https://cloud.google.com/load-balancing/docs/user-defined-request-headers#how_user-defined_request_headers_work
 
@@ -118,7 +120,10 @@ time before trying again.
 
 ## How GCP Identifies Client Location
 
-As mentioned above, the Locate service uses GCP to determine a client's location and direct the client to the nearest M-Lab server. Using the Locate service with no additional parameters will provide the Latitude & Longitude from Appengine. For example, see the query and response below:
+As mentioned above, the Locate service uses GCP to determine a client's 
+location and direct the client to the nearest M-Lab server. Using the Locate 
+service with no additional parameters will provide the Latitude & Longitude 
+from Appengine. For example, see the query and response below:
 
 ```
 $ curl --head 'http://locate.measurementlab.net/v2/nearest/ndt/ndt7'
@@ -135,11 +140,15 @@ Via: 1.1 google
 Transfer-Encoding: chunked
 ```
 
-In this case, the Locate service used the Appengine provided latitude and longitude values, derived from the [Appengine headers](headers), `X-Appengine-Country` and `X-Appengine-Region`.
+In this case, the Locate service used the Appengine provided latitude and 
+longitude values, derived from the [Appengine headers](headers), 
+`X-Appengine-Country` and `X-Appengine-Region`.
 
 [headers]: https://cloud.google.com/appengine/docs/flexible/go/reference/request-headers
 
-A client may also use Locate service and specify a `country` or `region` parameter to select a server nearest to that country or region. For example see the queries and responses below:
+A client may also use Locate service and specify a `country` or `region` 
+parameter to select a server nearest to that country or region. For example 
+see the queries and responses below:
 
 ```
 $ curl --head 'http://locate.measurementlab.net/v2/nearest/ndt/ndt7?country=IN
@@ -169,7 +178,14 @@ Via: 1.1 google
 Transfer-Encoding: chunked
 ```
 
-Countries are specified using the [ISO 3166-1 alpha 2 country code](iso1) (`country=IN`) or the [ISO 3166-2 region code](iso2) (`region=US-IL`).
+Countries are specified using the [ISO 3166-1 alpha 2 country code](iso1) 
+(`country=IN`) or the [ISO 3166-2 region code](iso2) (`region=US-IL`).
 
 [iso1]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [iso2]: https://en.wikipedia.org/wiki/ISO_3166-2
+
+ If Appengine does not know a client location, and the user does not provide a 
+ location parameter, then the Locate API falls back to using a current Maxmind 
+ db. If that also fails, then the Locate API will return a 503 error, Service 
+ Unavailable. If the client is connecting from an IP address with an unknown 
+ location, the Locate service cannot direct it to a nearby server.


### PR DESCRIPTION
This PR adds some detail to USAGE.md outlining how Appengine locates a client, and how the country and region parameters may be used to select an alternate location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/49)
<!-- Reviewable:end -->
