### PR TITLE
New monitoring-token flag + adds `results` key to monitoring responses

### DIFF
--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -55,6 +55,9 @@ type MonitoringResult struct {
 
 	// Target contains service URLs for monitoring the service on the target machine.
 	Target *Target `json:"target,omitempty"`
+
+	// Results contains an array of Targets matching the client request.
+	Results []Target `json:"results,omitempty"`
 }
 
 // NextRequest contains a URL for scheduling the next request. The URL embeds an

--- a/api/v2/api.go
+++ b/api/v2/api.go
@@ -53,10 +53,17 @@ type MonitoringResult struct {
 	// may use this value instead of specific Target.URLs.
 	AccessToken string `json:"access_token"`
 
-	// Target contains service URLs for monitoring the service on the target machine.
+	// Target contains service URLs for monitoring the service on the target
+	// machine.
+	// TODO (kinkade): Remove this field once all monitoring clients are using
+	// the Results field below.
 	Target *Target `json:"target,omitempty"`
 
-	// Results contains an array of Targets matching the client request.
+	// Results is array of Targets matching the client request. In the case of
+	// monitoring requests this array will only contain a single element, but we
+	// leave it as an array so that the response of monitoring requests matches
+	// the response of normal locate requests so that clients can treat data
+	// from either request the same.
 	Results []Target `json:"results,omitempty"`
 }
 

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -25,6 +25,7 @@ steps:
   - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-ns
   args:
   - cp cloudbuild/app-platform.yaml.$PROJECT_ID app.yaml
+  - gcloud config set app/cloud_build_timeout 900
   - gcloud --project $PROJECT_ID app deploy --promote app.yaml
 
 # Deployment of public APIs in sandbox & staging & mlab-ns. e.g. /v2/nearest/*

--- a/cmd/monitoring-token/monitoring-token.go
+++ b/cmd/monitoring-token/monitoring-token.go
@@ -33,8 +33,8 @@ var (
 	// TODO (kinkade): Remove these two variables and corresponding flag
 	// definitions once all monitoring clients are migrated to use only
 	// monitoring URLs.
-	serviceURL    bool
-	resultKeyName string
+	serviceURL        bool
+	serviceURLKeyName string
 )
 
 func init() {
@@ -49,7 +49,7 @@ func setupFlags() {
 	flag.DurationVar(&timeout, "timeout", 60*time.Second, "Complete request and command execution within timeout")
 	flag.StringVar(&envName, "env-name", "MONITORING_URL", "Export the monitoring locate URL to the named environment variable before executing given command")
 	flag.BoolVar(&serviceURL, "service-url", false, "Return a service URL instead of the default monitoring locate URL")
-	flag.StringVar(&resultKeyName, "result-key-name", "wss://:3010/ndt_protocol", "The key name to extract from the locate result Target.URLs")
+	flag.StringVar(&serviceURLKeyName, "service-url-key-name", "wss://:3010/ndt_protocol", "The key name to extract from the monitoring locate result Target.URLs")
 }
 
 func main() {
@@ -106,7 +106,7 @@ func main() {
 			logFatalf("ERROR: monitoring result Target field is nil!")
 			return
 		}
-		envValue = mr.Target.URLs[resultKeyName]
+		envValue = mr.Target.URLs[serviceURLKeyName]
 	} else {
 		envValue = locate.String()
 	}

--- a/cmd/monitoring-token/monitoring-token.go
+++ b/cmd/monitoring-token/monitoring-token.go
@@ -48,7 +48,6 @@ func setupFlags() {
 	flag.StringVar(&service, "service", "ndt/ndt5", "<experiment>/<datatype> to request monitoring access tokens")
 	flag.DurationVar(&timeout, "timeout", 60*time.Second, "Complete request and command execution within timeout")
 	flag.StringVar(&envName, "env-name", "MONITORING_URL", "Export the monitoring locate URL to the named environment variable before executing given command")
-	flag.StringVar(&envValue, "env-value", "", "The value of the named environment variable envName")
 	flag.BoolVar(&serviceURL, "service-url", false, "Return a service URL instead of the default monitoring locate URL")
 	flag.StringVar(&resultKeyName, "result-key-name", "wss://:3010/ndt_protocol", "The key name to extract from the locate result Target.URLs")
 }

--- a/cmd/monitoring-token/monitoring-token_test.go
+++ b/cmd/monitoring-token/monitoring-token_test.go
@@ -35,16 +35,16 @@ func Test_main(t *testing.T) {
 			args: []string{"monitoring-token"},
 		},
 		{
-			name: "error-args-len-zero",
+			name: "error-args-target-len-zero",
 			resp: `{"target": {"urls": {"wss://:3010/ndt_protocol":""}}}`,
-			args: []string{"monitoring-token"},
+			args: []string{"monitoring-token", "-service-url"},
 		},
 		{
-			name: "success-target-urls-value-matches-check_env-arg",
+			name: "success-service-url-value-matches-check_env-arg",
 			// The value "FAKE_URL" is provided to the check_env.sh command via the environment.
 			// The argument to check_env.sh is the value it expects in the SERVICE_URL env variable.
 			resp: `{"target": {"urls": {"wss://:3010/ndt_protocol":"FAKE_VALUE"}}}`,
-			args: []string{"monitoring-token", "--", "testdata/check_env.sh", "FAKE_VALUE"},
+			args: []string{"monitoring-token", "-service-url", "-env-name=SVC_URL", "--", "testdata/check_env.sh", "SVC_URL", "FAKE_VALUE"},
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/monitoring-token/monitoring-token_test.go
+++ b/cmd/monitoring-token/monitoring-token_test.go
@@ -25,17 +25,17 @@ func Test_main(t *testing.T) {
 		args []string
 	}{
 		{
-			name: "error-error-not-nil",
+			name: "error-service-url-error-not-nil",
 			resp: `{"error":{"type":"fake-error"}}`,
-			args: []string{"monitoring-token"},
+			args: []string{"monitoring-token", "-service-url"},
 		},
 		{
-			name: "error-nil-target",
+			name: "error-service-url-nil-target",
 			resp: `{}`,
-			args: []string{"monitoring-token"},
+			args: []string{"monitoring-token", "-service-url"},
 		},
 		{
-			name: "error-args-target-len-zero",
+			name: "error-service-url-args-target-len-zero",
 			resp: `{"target": {"urls": {"wss://:3010/ndt_protocol":""}}}`,
 			args: []string{"monitoring-token", "-service-url"},
 		},
@@ -45,6 +45,11 @@ func Test_main(t *testing.T) {
 			// The argument to check_env.sh is the value it expects in the SERVICE_URL env variable.
 			resp: `{"target": {"urls": {"wss://:3010/ndt_protocol":"FAKE_VALUE"}}}`,
 			args: []string{"monitoring-token", "-service-url", "-env-name=SVC_URL", "--", "testdata/check_env.sh", "SVC_URL", "FAKE_VALUE"},
+		},
+		{
+			name: "success-locate-monitoring-url",
+			resp: `{}`,
+			args: []string{"monitoring-token"},
 		},
 	}
 	for _, tt := range tests {

--- a/cmd/monitoring-token/testdata/check_env.sh
+++ b/cmd/monitoring-token/testdata/check_env.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-if [[ -z "${SERVICE_URL}" ]] ; then
-    echo "SERVICE_URL is undefined"
+ENV_NAME=$1
+ENV_VALUE=$2
+
+if [[ -z "${!ENV_NAME}" ]] ; then
+    echo "${ENV_NAME} is undefined"
     exit 1
 fi
-if [[ ${SERVICE_URL} != "$1" ]] ; then
-    echo "SERVICE_URL: UNEXPECTED VALUE: $SERVICE_URL"
+if [[ ${!ENV_NAME} != "${ENV_VALUE}" ]] ; then
+    echo "${ENV_NAME}: UNEXPECTED VALUE: ${!ENV_NAME}"
     exit 1
 fi

--- a/handler/monitoring.go
+++ b/handler/monitoring.go
@@ -48,5 +48,9 @@ func (c *Client) Monitoring(rw http.ResponseWriter, req *http.Request) {
 		Machine: machine,
 		URLs:    urls,
 	}
+	result.Results = append(result.Results, v2.Target{
+		Machine: machine,
+		URLs:    urls,
+	})
 	writeResult(rw, http.StatusOK, &result)
 }


### PR DESCRIPTION
This PR has two components:

* adds a new flag `-monitoring-url-only`, which will cause the monitoring-token command to set the environment variable (named by `-env-name`) with a value of the authenticated /v2/monitoring URL rather than a service URL. The impetus for this is the wehe-cmdline client, which accepts a `-m` flag which sets the URL at which to query the M-Lab locate service.
* Currently, the locate service returns different data for "normal" locate queries and "monitoring" queries. This means that clients cannot consistently parse the results of both using the same code. This PR adds a new `results` key to the monitoring response which matches the format of a normal locate query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/51)
<!-- Reviewable:end -->
