### PR TITLE
Maps wehe/replay to mlab-ns/wehe, not ndt7

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -58,7 +58,7 @@ type Ports []url.URL
 // v2 equivalent.
 var LegacyServices = map[string]string{
 	"neubot/dash": "neubot",
-	"wehe/replay": "ndt7", // TODO: replace with heartbeat health.
+	"wehe/replay": "wehe", // TODO: replace with heartbeat health.
 	"iperf3/test": "ndt7", // TODO: replace with heartbeat health.
 	"ndt/ndt5":    "ndt_ssl",
 	"ndt/ndt7":    "ndt7",


### PR DESCRIPTION
This PR maps `wehe/replay` to an actual live wehe status from mlab-ns. It is intended to resolve #47.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/52)
<!-- Reviewable:end -->
