### PR TITLE
Adds new package named secrets

### DIFF
--- a/secrets/load.go
+++ b/secrets/load.go
@@ -57,7 +57,7 @@ func (c *Config) getSecret(ctx context.Context, client SecretClient, path string
 
 	result, err := client.AccessSecretVersion(ctx, req)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	return result.Payload.Data, nil

--- a/secrets/load.go
+++ b/secrets/load.go
@@ -1,4 +1,4 @@
-// Package secrets loads secrets from the Google Cloud Secret Manager
+// Package secrets loads secrets from the Google Cloud Secret Manager.
 package secrets
 
 import (

--- a/secrets/load.go
+++ b/secrets/load.go
@@ -1,0 +1,131 @@
+// Package secrets loads secrets from the Google Cloud Secret Manager
+package secrets
+
+import (
+	"context"
+	"fmt"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"github.com/googleapis/gax-go"
+	"github.com/m-lab/access/token"
+	"google.golang.org/api/iterator"
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+)
+
+// SecretClient wraps the AccessSecretVersion function provided by the
+// secretmanager.Client.
+type SecretClient interface {
+	AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
+	ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *secretmanager.SecretVersionIterator
+}
+
+// iter warps the Next() method of a *secretmanager.SecretVersionIterator.
+type iter interface {
+	Next(it *secretmanager.SecretVersionIterator) (*secretmanagerpb.SecretVersion, error)
+}
+
+// stdIter implements the iter interfaces, and is used to invoke the
+// iterator.Next() method.
+type stdIter struct{}
+
+// Next invokes the Next() method of a *secretmanager.SecretVersionIterator.
+func (s *stdIter) Next(it *secretmanager.SecretVersionIterator) (*secretmanagerpb.SecretVersion, error) {
+	return it.Next()
+}
+
+// Config contains settings for secrets.
+type Config struct {
+	iter    iter
+	Name    string
+	Project string
+}
+
+// NewConfig creates a new secret config.
+func NewConfig(project string) *Config {
+	return &Config{
+		iter:    &stdIter{},
+		Project: project,
+	}
+}
+
+// getSecret fetches the version of a secret specified by 'path' from the Secret
+// Manager API.
+func (c *Config) getSecret(ctx context.Context, client SecretClient, path string) ([]byte, error) {
+	req := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: path,
+	}
+
+	result, err := client.AccessSecretVersion(ctx, req)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return result.Payload.Data, nil
+}
+
+// getSecretVersions returns a slice of all *enabled* versions for a secret. It
+// will ignore disabled for destroyed versions of a secret.
+func (c *Config) getSecretVersions(ctx context.Context, client SecretClient) ([]string, error) {
+	req := &secretmanagerpb.ListSecretVersionsRequest{
+		Parent:   c.path(),
+		PageSize: 1000,
+	}
+
+	it := client.ListSecretVersions(ctx, req)
+	versions := []string{}
+	for {
+		resp, err := c.iter.Next(it)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if resp.State != secretmanagerpb.SecretVersion_ENABLED {
+			continue
+		}
+		versions = append(versions, resp.Name)
+	}
+
+	if len(versions) < 1 {
+		return nil, fmt.Errorf("no versions found for secret: %s", c.Name)
+	}
+
+	return versions, nil
+}
+
+// LoadSigner fetches the latest version of the named secret containing the JWT
+// signer key from the Secret Manager API and returns a *token.Signer.
+func (c *Config) LoadSigner(ctx context.Context, client SecretClient) (*token.Signer, error) {
+	versions, err := c.getSecretVersions(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	key, err := c.getSecret(ctx, client, versions[0])
+	if err != nil {
+		return nil, err
+	}
+	return token.NewSigner(key)
+}
+
+// LoadVerifier fetches all enabled versions of the named secret containing the
+// JWT verifier keys and returns a * token.Verifier.
+func (c *Config) LoadVerifier(ctx context.Context, client SecretClient) (*token.Verifier, error) {
+	versions, err := c.getSecretVersions(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	keys := [][]byte{}
+	for _, version := range versions {
+		key, err := c.getSecret(ctx, client, version)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return token.NewVerifier(keys...)
+}
+
+func (c *Config) path() string {
+	return "projects/" + c.Project + "/secrets/" + c.Name
+}

--- a/secrets/load_test.go
+++ b/secrets/load_test.go
@@ -74,24 +74,36 @@ func Test_getSecret(t *testing.T) {
 
 	var secretData [][]byte
 	secretData = append(secretData, []byte("fake-secret"))
-	client := &fakeSecretClient{
-		data:    secretData,
-		wantErr: false,
+
+	tests := []struct {
+		wantErr bool
+	}{
+		{
+			wantErr: false,
+		},
+		{
+			wantErr: true,
+		},
 	}
 
-	secret, err := cfg.getSecret(ctx, client, "fake-path")
-	if err != nil {
-		t.Fatalf("Did not expect an error, but got error: %s", err)
-	}
-	if string(secret) != string(secretData[0]) {
-		t.Fatalf("Expected secret value '%s', but got: %s", string(secretData[0]), string(secret))
-	}
+	for _, tt := range tests {
+		client := &fakeSecretClient{
+			data:    secretData,
+			wantErr: tt.wantErr,
+		}
 
-	client.wantErr = true
+		secret, err := cfg.getSecret(ctx, client, "fake-path")
 
-	_, err = cfg.getSecret(ctx, client, "fake-path")
-	if err == nil {
-		t.Fatal("Wanted error, but did not get one.")
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("Got error: %v, but wantErr is %v", err, tt.wantErr)
+			return
+		}
+
+		if !tt.wantErr {
+			if string(secret) != string(secretData[0]) {
+				t.Fatalf("Expected secret value '%s', but got: %s", string(secretData[0]), string(secret))
+			}
+		}
 	}
 }
 
@@ -160,7 +172,8 @@ func Test_getSecretVersions(t *testing.T) {
 		versions, err := cfg.getSecretVersions(ctx, client)
 
 		if (err != nil) != tt.wantErr {
-			t.Fatalf("Did not expect error, but got error: %s", err)
+			t.Fatalf("Got error: %v, but wantErr is %v", err, tt.wantErr)
+			return
 		}
 
 		if len(versions) != tt.expectedCount {
@@ -256,9 +269,8 @@ func Test_LoadSigner(t *testing.T) {
 		_, err := cfg.LoadSigner(ctx, tt.client)
 
 		if (err != nil) != tt.wantErr {
-			t.Fatalf("Did not expect error, but got error: %s", err)
+			t.Fatalf("Got error: %v, but wantErr is %v", err, tt.wantErr)
 		}
-
 	}
 }
 
@@ -358,8 +370,7 @@ func Test_LoadVerifier(t *testing.T) {
 		_, err := cfg.LoadVerifier(ctx, tt.client)
 
 		if (err != nil) != tt.wantErr {
-			t.Fatalf("Did not expect error, but got error: %s", err)
+			t.Fatalf("Got error: %v, but wantErr is %v", err, tt.wantErr)
 		}
-
 	}
 }

--- a/secrets/load_test.go
+++ b/secrets/load_test.go
@@ -1,0 +1,384 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"github.com/googleapis/gax-go"
+	"google.golang.org/api/iterator"
+	secretmanagerpb "google.golang.org/genproto/googleapis/cloud/secretmanager/v1"
+)
+
+type fakeSecretClient struct {
+	idx     int
+	data    [][]byte
+	wantErr bool
+}
+
+func (f *fakeSecretClient) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+	defer f.incrementIdx()
+	if !f.wantErr {
+		return &secretmanagerpb.AccessSecretVersionResponse{
+			Name: "fake-secret",
+			Payload: &secretmanagerpb.SecretPayload{
+				Data: f.data[f.idx],
+			},
+		}, nil
+	}
+
+	if f.wantErr {
+		return nil, fmt.Errorf("fake-error")
+	}
+
+	return &secretmanagerpb.AccessSecretVersionResponse{}, nil
+}
+
+func (f *fakeSecretClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *secretmanager.SecretVersionIterator {
+	return &secretmanager.SecretVersionIterator{}
+}
+
+func (f *fakeSecretClient) incrementIdx() {
+	f.idx = f.idx + 1
+}
+
+type fakeIter struct {
+	idx      int
+	versions []*secretmanagerpb.SecretVersion
+	err      string
+}
+
+func (f *fakeIter) Next(it *secretmanager.SecretVersionIterator) (*secretmanagerpb.SecretVersion, error) {
+	defer f.incrementIdx()
+
+	if f.err == "no-errors" {
+		if f.idx == len(f.versions) {
+			return nil, iterator.Done
+		}
+		return &secretmanagerpb.SecretVersion{
+			Name:  f.versions[f.idx].Name,
+			State: f.versions[f.idx].State,
+		}, nil
+	}
+
+	if f.err == "no-versions" {
+		if f.idx == len(f.versions) {
+			return nil, iterator.Done
+		}
+		return &secretmanagerpb.SecretVersion{
+			Name:  f.versions[f.idx].Name,
+			State: f.versions[f.idx].State,
+		}, nil
+	}
+
+	if f.err == "iterator-error" {
+		return nil, fmt.Errorf("fake-error")
+	}
+
+	return nil, iterator.Done
+}
+
+func (f *fakeIter) incrementIdx() {
+	f.idx = f.idx + 1
+}
+
+func Test_getSecret(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := NewConfig("mlab-sandbox")
+	cfg.iter = &fakeIter{}
+
+	var secretData [][]byte
+	secretData = append(secretData, []byte("fake-secret"))
+	client := &fakeSecretClient{
+		data:    secretData,
+		wantErr: false,
+	}
+
+	secret, err := cfg.getSecret(ctx, client, "fake-path")
+	if err != nil {
+		t.Fatalf("Did not expect an error, but got error: %s", err)
+	}
+	if string(secret) != string(secretData[0]) {
+		t.Fatalf("Expected secret value '%s', but got: %s", string(secretData[0]), string(secret))
+	}
+
+	client.wantErr = true
+
+	_, err = cfg.getSecret(ctx, client, "fake-path")
+	if err == nil {
+		t.Fatal("Wanted error, but did not get one.")
+	}
+}
+
+func Test_getSecretVersions(t *testing.T) {
+	ctx := context.Background()
+	cfg := NewConfig("mlab-sandbox")
+	client := &fakeSecretClient{}
+
+	tests := []struct {
+		name             string
+		expectedCount    int
+		expectedVersions []string
+		versions         []*secretmanagerpb.SecretVersion
+		wantErr          bool
+	}{
+		{
+			name:          "no-errors",
+			expectedCount: 2,
+			expectedVersions: []string{
+				"secrets/mlab-sandbox/fake-secret/versions/3",
+				"secrets/mlab-sandbox/fake-secret/versions/1",
+			},
+			versions: []*secretmanagerpb.SecretVersion{
+				{
+					Name:  "secrets/mlab-sandbox/fake-secret/versions/4",
+					State: secretmanagerpb.SecretVersion_DISABLED,
+				},
+				{
+					Name:  "secrets/mlab-sandbox/fake-secret/versions/3",
+					State: secretmanagerpb.SecretVersion_ENABLED,
+				},
+				{
+					Name:  "secrets/mlab-sandbox/fake-secret/versions/2",
+					State: secretmanagerpb.SecretVersion_DESTROYED,
+				},
+				{
+					Name:  "secrets/mlab-sandbox/fake-secret/versions/1",
+					State: secretmanagerpb.SecretVersion_ENABLED,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "no-versions",
+			versions: []*secretmanagerpb.SecretVersion{
+				{
+					Name:  "secrets/mlab-sandbox/fake-secret/versions/4",
+					State: secretmanagerpb.SecretVersion_DISABLED,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "iterator-error",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		cfg.iter = &fakeIter{
+			err:      tt.name,
+			versions: tt.versions,
+		}
+		versions, err := cfg.getSecretVersions(ctx, client)
+
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("Did not expect error, but got error: %s", err)
+		}
+
+		if len(versions) != tt.expectedCount {
+			t.Fatalf("Expected 2 secret versions, but got %d", len(versions))
+		}
+
+		for i, v := range tt.expectedVersions {
+			if v != versions[i] {
+				t.Fatalf("Expected versions:\n\n%v\n\n...but got:\n\n%v", tt.expectedVersions, versions)
+			}
+		}
+	}
+}
+
+func Test_LoadSigner(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := NewConfig("mlab-sandbox")
+	cfg.iter = &fakeIter{}
+
+	var signerKeys [][]byte
+
+	signerData := `
+		{
+			"use": "sig",
+			"kty": "OKP",
+			"kid": "fake_20210721",
+			"crv": "Ed25519",
+			"alg": "EdDSA",
+			"x": "abcde-abcd-abcdefghijklmnopqrstuv-abcdefghi",
+			"d": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr"
+		}
+	`
+	signerKeys = append(signerKeys, []byte(signerData))
+
+	tests := []struct {
+		name    string
+		client  SecretClient
+		iter    iter
+		wantErr bool
+	}{
+		{
+			name: "no-errors",
+			client: &fakeSecretClient{
+				data:    signerKeys,
+				wantErr: false,
+			},
+			iter: &fakeIter{
+				err: "no-errors",
+				versions: []*secretmanagerpb.SecretVersion{
+					{
+						Name:  "secrets/mlab-sandbox/fake-secret/versions/4",
+						State: secretmanagerpb.SecretVersion_ENABLED,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "get-secret-versions-error",
+			client: &fakeSecretClient{
+				wantErr: false,
+			},
+			iter: &fakeIter{
+				err: "no-versions",
+				versions: []*secretmanagerpb.SecretVersion{
+					{
+						Name:  "secrets/mlab-sandbox/fake-secret/versions/2",
+						State: secretmanagerpb.SecretVersion_DISABLED,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "get-secret-error",
+			client: &fakeSecretClient{
+				wantErr: true,
+			},
+			iter: &fakeIter{
+				err: "no-errors",
+				versions: []*secretmanagerpb.SecretVersion{
+					{
+						Name:  "secrets/mlab-sandbox/fake-secret/versions/2",
+						State: secretmanagerpb.SecretVersion_ENABLED,
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		cfg.iter = tt.iter
+		_, err := cfg.LoadSigner(ctx, tt.client)
+
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("Did not expect error, but got error: %s", err)
+		}
+
+	}
+}
+
+func Test_LoadVerifier(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := NewConfig("mlab-sandbox")
+	cfg.iter = &fakeIter{}
+
+	var verifyKeys [][]byte
+
+	verifyData0 := `
+		{
+			"use": "sig",
+			"kty": "OKP",
+			"kid": "fake0_20210721",
+			"crv": "Ed25519",
+			"alg": "EdDSA",
+			"x": "abcde-abcd-abcdefghijklmnopqrstuv-abcdefghi"
+		}
+	`
+	verifyKeys = append(verifyKeys, []byte(verifyData0))
+
+	verifyData1 := `
+		{
+			"use": "sig",
+			"kty": "OKP",
+			"kid": "fake1_20210721",
+			"crv": "Ed25519",
+			"alg": "EdDSA",
+			"x": "abcde-abcd-abcdefghijklmnopqrstuv-abcdefghi"
+		}
+	`
+	verifyKeys = append(verifyKeys, []byte(verifyData1))
+
+	tests := []struct {
+		name    string
+		client  SecretClient
+		iter    iter
+		wantErr bool
+	}{
+		{
+			name: "no-errors",
+			client: &fakeSecretClient{
+				data:    verifyKeys,
+				wantErr: false,
+			},
+			iter: &fakeIter{
+				err: "no-errors",
+				versions: []*secretmanagerpb.SecretVersion{
+					{
+						Name:  "secrets/mlab-sandbox/fake-secret/versions/4",
+						State: secretmanagerpb.SecretVersion_ENABLED,
+					},
+					{
+						Name:  "secrets/mlab-sandbox/fake-secret/versions/2",
+						State: secretmanagerpb.SecretVersion_ENABLED,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "get-secret-versions-error",
+			client: &fakeSecretClient{
+				wantErr: false,
+			},
+			iter: &fakeIter{
+				err: "no-versions",
+				versions: []*secretmanagerpb.SecretVersion{
+					{
+						Name:  "secrets/mlab-sandbox/fake-secret/versions/2",
+						State: secretmanagerpb.SecretVersion_DISABLED,
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "get-secret-error",
+			client: &fakeSecretClient{
+				wantErr: true,
+			},
+			iter: &fakeIter{
+				err: "no-errors",
+				versions: []*secretmanagerpb.SecretVersion{
+					{
+						Name:  "secrets/mlab-sandbox/fake-secret/versions/2",
+						State: secretmanagerpb.SecretVersion_ENABLED,
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		cfg.iter = tt.iter
+		_, err := cfg.LoadVerifier(ctx, tt.client)
+
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("Did not expect error, but got error: %s", err)
+		}
+
+	}
+}

--- a/secrets/load_test.go
+++ b/secrets/load_test.go
@@ -19,20 +19,17 @@ type fakeSecretClient struct {
 
 func (f *fakeSecretClient) AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error) {
 	defer f.incrementIdx()
-	if !f.wantErr {
-		return &secretmanagerpb.AccessSecretVersionResponse{
-			Name: "fake-secret",
-			Payload: &secretmanagerpb.SecretPayload{
-				Data: f.data[f.idx],
-			},
-		}, nil
-	}
 
 	if f.wantErr {
 		return nil, fmt.Errorf("fake-error")
 	}
 
-	return &secretmanagerpb.AccessSecretVersionResponse{}, nil
+	return &secretmanagerpb.AccessSecretVersionResponse{
+		Name: "fake-secret",
+		Payload: &secretmanagerpb.SecretPayload{
+			Data: f.data[f.idx],
+		},
+	}, nil
 }
 
 func (f *fakeSecretClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *secretmanager.SecretVersionIterator {


### PR DESCRIPTION
This PR adds a new package named `secrets`. It serves the same general purpose as the current `decrypt` package, but uses a different backing mechanism. Instead of using the GCP Key Management Service (KMS) (like `decrypt`), this new package uses the GCP Secret Manager (SM).

The primary motivation for moving to the SM is that, currently, the signer and verify keys for the Locate Service are stored in this public repository in encrypted form. It is probably safe, but perhaps better to remove them altogether in any form. Moving to the SM allows us to remove the keys 100% from this repo. This new module will allow the Locate Service to fetch the keys directly from the SM at runtime.

Another advantage of using the SM over KMS, is that the SM natively supports secret versions, which will allow us to more easily rotate the keys in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/54)
<!-- Reviewable:end -->
