### PR TITLE
Add heartbeat service connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,9 @@ script:
 - go vet ./...
 - go test ./... -cover=1 -coverprofile=_c.cov
 - go test ./... -race
+
+after_success:
+# Note: Do this in the after_success stage so that
+# a broken coveralls won't cause the build to fail.
+# (details: https://github.com/lemurheavy/coveralls-public/issues/1264)
 - $GOPATH/bin/goveralls -service=travis-ci -coverprofile=_c.cov

--- a/cmd/heartbeat/README.md
+++ b/cmd/heartbeat/README.md
@@ -1,18 +1,19 @@
 # Heartbeat Service
 
 The Heartbeat Service is a sidecar service that performs health checks
-for experiment instances running in the same Kubernetes pod.
+for experiment instances running in the same Kubernetes pod and reports
+them to the Locate API.
 
 On start, it establishes a WebSocket connection with the Locate Service
 and sends an initial registration message. Subsequently, it performs
-periodic instance health checks and sends the results to the Locate.
+periodic instance health checks and sends the results to the Locate API.
 
 ## Local Development
 
 To run the service locally, build the package and pass a test URL
-in the `-locate-url` flag.
+in the `-heartbeat-url` flag.
 
 ```sh
 $ go build
-$ ./heartbeat -locate-url=ws://locate-dot-mlab-sandbox.appspot.com/v2/platform/heartbeat/
+$ ./heartbeat -heartbeat-url=ws://locate-dot-mlab-sandbox.appspot.com/v2/platform/heartbeat/
 ```

--- a/cmd/heartbeat/README.md
+++ b/cmd/heartbeat/README.md
@@ -1,0 +1,18 @@
+# Heartbeat Service
+
+The Heartbeat Service is a sidecar service that performs health checks
+for experiment instances running in the same Kubernetes pod.
+
+On start, it establishes a WebSocket connection with the Locate Service
+and sends an initial registration message. Subsequently, it performs
+periodic instance health checks and sends the results to the Locate.
+
+## Local Development
+
+To run the service locally, build the package and pass a test URL
+in the `-locate-url` flag.
+
+```sh
+$ go build
+$ ./heartbeat -locate-url=ws://locate-dot-mlab-sandbox.appspot.com/v2/platform/heartbeat/
+```

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -22,7 +22,7 @@ func init() {
 
 func main() {
 	flag.Parse()
-	rtx.Must(flagx.ArgsFromEnvWithLog(flag.CommandLine, false), "Failed to read args from env")
+	rtx.Must(flagx.ArgsFromEnvWithLog(flag.CommandLine, false), "failed to read args from env")
 
 	conn := connection.NewConn()
 	conn.Dial(locate, http.Header{})

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	locate              string
+	heartbeatURL        string
 	heartbeatPeriod     = static.HeartbeatPeriod
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 )
 
 func init() {
-	flag.StringVar(&locate, "locate-url", "ws://localhost:8080/v2/platform/heartbeat/",
+	flag.StringVar(&heartbeatURL, "heartbeat-url", "ws://localhost:8080/v2/platform/heartbeat/",
 		"URL for locate service")
 }
 
@@ -30,8 +30,8 @@ func main() {
 	rtx.Must(flagx.ArgsFromEnvWithLog(flag.CommandLine, false), "failed to read args from env")
 
 	conn := connection.NewConn()
-	err := conn.Dial(locate, http.Header{})
-	rtx.Must(err, "failed to establish a websocket connection with %s", locate)
+	err := conn.Dial(heartbeatURL, http.Header{})
+	rtx.Must(err, "failed to establish a websocket connection with %s", heartbeatURL)
 
 	write(conn)
 }

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	locate              string
+	heartbeatPeriod     = static.HeartbeatPeriod
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 )
 
@@ -39,7 +40,7 @@ func main() {
 // HeartbeatPeriod.
 func write(ws *connection.Conn) {
 	defer ws.Close()
-	ticker := *time.NewTicker(static.HeartbeatPeriod)
+	ticker := *time.NewTicker(heartbeatPeriod)
 	defer ticker.Stop()
 
 	for {

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -16,7 +16,6 @@ import (
 
 var (
 	locate              string
-	heartbeatPeriod = static.HeartbeatPeriod
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 )
 
@@ -40,7 +39,7 @@ func main() {
 // HeartbeatPeriod.
 func write(ws *connection.Conn) {
 	defer ws.Close()
-	ticker := *time.NewTicker(heartbeatPeriod)
+	ticker := *time.NewTicker(static.HeartbeatPeriod)
 	defer ticker.Stop()
 
 	for {

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/locate/connection"
+	"github.com/m-lab/locate/static"
+)
+
+var locate string
+
+func init() {
+	flag.StringVar(&locate, "locate-url", "ws://localhost:8080/v2/platform/heartbeat/",
+		"URL for locate service")
+}
+
+func main() {
+	flag.Parse()
+	rtx.Must(flagx.ArgsFromEnvWithLog(flag.CommandLine, false), "Failed to read args from env")
+
+	conn := connection.NewConn()
+	conn.Dial(locate, http.Header{})
+	write(conn)
+}
+
+// write starts a write loop to send health messages every
+// HeartbeatPeriod.
+func write(ws *connection.Conn) {
+	defer ws.Close()
+	ticker := time.NewTicker(static.HeartbeatPeriod)
+	defer ticker.Stop()
+
+	for {
+		<-ticker.C
+		err := ws.WriteMessage(websocket.TextMessage, []byte("Health message!"))
+		if err != nil {
+			log.Printf("failed to write, err: %v", err)
+		}
+	}
+}

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -1,1 +1,27 @@
 package main
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/m-lab/locate/connection/testdata"
+)
+
+func Test_main(t *testing.T) {
+	s := testdata.FakeServer()
+	defer s.Close()
+
+	flag.Set("locate-url", s.URL)
+
+	timer := time.NewTimer(time.Second)
+	go func() {
+		<-timer.C
+		if locate != s.URL {
+			t.Error("main() incorrect locate URL")
+		}
+		done <- true
+	}()
+
+	main()
+}

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -1,31 +1,31 @@
 package main
 
-// import (
-// 	"context"
-// 	"flag"
-// 	"testing"
-// 	"time"
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
 
-// 	"github.com/m-lab/locate/connection/testdata"
-// )
+	"github.com/m-lab/locate/connection/testdata"
+)
 
-// func Test_main(t *testing.T) {
-// 	mainCtx, mainCancel = context.WithCancel(context.Background())
-// 	fh := testdata.FakeHandler{}
-// 	s := testdata.FakeServer(fh.Upgrade)
-// 	defer s.Close()
+func Test_main(t *testing.T) {
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+	fh := testdata.FakeHandler{}
+	s := testdata.FakeServer(fh.Upgrade)
+	defer s.Close()
 
-// 	flag.Set("locate-url", s.URL)
+	flag.Set("locate-url", s.URL)
 
-// 	timer := time.NewTimer(time.Second)
-// 	go func() {
-// 		<-timer.C
-// 		if locate != s.URL {
-// 			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
-// 				locate, s.URL)
-// 		}
-// 		mainCancel()
-// 	}()
+	timer := time.NewTimer(time.Second)
+	go func() {
+		<-timer.C
+		if locate != s.URL {
+			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
+				locate, s.URL)
+		}
+		mainCancel()
+	}()
 
-// 	main()
-// }
+	main()
+}

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -25,7 +25,9 @@ func Test_main(t *testing.T) {
 			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
 				locate, s.URL)
 		}
-		if fh.ReadError() != nil {
+
+		msg, err := fh.Read()
+		if msg == nil || err != nil {
 			t.Errorf("main() failed to write heartbeat message")
 		}
 

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -17,20 +17,13 @@ func Test_main(t *testing.T) {
 
 	flag.Set("locate-url", s.URL)
 
-	heartbeatPeriod = 2 * time.Second
-	timer := time.NewTimer(2 * heartbeatPeriod)
+	timer := time.NewTimer(time.Second)
 	go func() {
 		<-timer.C
 		if locate != s.URL {
 			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
 				locate, s.URL)
 		}
-
-		msg, err := fh.Read()
-		if msg == nil || err != nil {
-			t.Errorf("main() failed to write heartbeat message")
-		}
-
 		mainCancel()
 	}()
 

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -18,7 +18,8 @@ func Test_main(t *testing.T) {
 	go func() {
 		<-timer.C
 		if locate != s.URL {
-			t.Error("main() incorrect locate URL")
+			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
+				locate, s.URL)
 		}
 		done <- true
 	}()

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -15,15 +15,15 @@ func Test_main(t *testing.T) {
 	s := testdata.FakeServer(fh.Upgrade)
 	defer s.Close()
 
-	flag.Set("locate-url", s.URL)
+	flag.Set("heartbeat-url", s.URL)
 
 	heartbeatPeriod = 2 * time.Second
 	timer := time.NewTimer(2 * heartbeatPeriod)
 	go func() {
 		<-timer.C
-		if locate != s.URL {
+		if heartbeatURL != s.URL {
 			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
-				locate, s.URL)
+				heartbeatURL, s.URL)
 		}
 
 		msg, err := fh.Read()

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -1,31 +1,31 @@
 package main
 
-import (
-	"context"
-	"flag"
-	"testing"
-	"time"
+// import (
+// 	"context"
+// 	"flag"
+// 	"testing"
+// 	"time"
 
-	"github.com/m-lab/locate/connection/testdata"
-)
+// 	"github.com/m-lab/locate/connection/testdata"
+// )
 
-func Test_main(t *testing.T) {
-	mainCtx, mainCancel = context.WithCancel(context.Background())
-	fh := testdata.FakeHandler{}
-	s := testdata.FakeServer(fh.Upgrade)
-	defer s.Close()
+// func Test_main(t *testing.T) {
+// 	mainCtx, mainCancel = context.WithCancel(context.Background())
+// 	fh := testdata.FakeHandler{}
+// 	s := testdata.FakeServer(fh.Upgrade)
+// 	defer s.Close()
 
-	flag.Set("locate-url", s.URL)
+// 	flag.Set("locate-url", s.URL)
 
-	timer := time.NewTimer(time.Second)
-	go func() {
-		<-timer.C
-		if locate != s.URL {
-			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
-				locate, s.URL)
-		}
-		mainCancel()
-	}()
+// 	timer := time.NewTimer(time.Second)
+// 	go func() {
+// 		<-timer.C
+// 		if locate != s.URL {
+// 			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
+// 				locate, s.URL)
+// 		}
+// 		mainCancel()
+// 	}()
 
-	main()
-}
+// 	main()
+// }

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"testing"
 	"time"
@@ -9,19 +10,26 @@ import (
 )
 
 func Test_main(t *testing.T) {
-	s := testdata.FakeServer()
+	mainCtx, mainCancel = context.WithCancel(context.Background())
+	fh := testdata.FakeHandler{}
+	s := testdata.FakeServer(fh.Upgrade)
 	defer s.Close()
 
 	flag.Set("locate-url", s.URL)
 
-	timer := time.NewTimer(time.Second)
+	heartbeatPeriod = 2 * time.Second
+	timer := time.NewTimer(2 * heartbeatPeriod)
 	go func() {
 		<-timer.C
 		if locate != s.URL {
 			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
 				locate, s.URL)
 		}
-		done <- true
+		if fh.ReadError() != nil {
+			t.Errorf("main() failed to write heartbeat message")
+		}
+
+		mainCancel()
 	}()
 
 	main()

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -17,13 +17,20 @@ func Test_main(t *testing.T) {
 
 	flag.Set("locate-url", s.URL)
 
-	timer := time.NewTimer(time.Second)
+	heartbeatPeriod = 2 * time.Second
+	timer := time.NewTimer(2 * heartbeatPeriod)
 	go func() {
 		<-timer.C
 		if locate != s.URL {
 			t.Errorf("main() incorrect locate URL; got: %s, want: %s",
 				locate, s.URL)
 		}
+
+		msg, err := fh.Read()
+		if msg == nil || err != nil {
+			t.Errorf("write() did not send heartbeat message")
+		}
+
 		mainCancel()
 	}()
 

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -257,11 +257,10 @@ func (c *Conn) connect() error {
 // It returns an error if the calls to NextWriter or WriteMessage
 // return errors.
 func (c *Conn) write(messageType int, data []byte) error {
-	// It is the call to NextWriter that updates writeErr internally:
-	// https://github.com/gorilla/websocket/blob/78cf1bc733a927f673fd1988a25256b425552a8a/conn.go#L489.
-	// Then, the error is returned in the call to WriteMessage.
-	// Calling NextWriter/WriteMessage by itself has a delay of
-	// one call to detect a disconnect.
+	// We want to identify and return write errors as soon as they occur.
+	// The supported interface for WriteMessage does not do that.
+	// Therefore, we are using NextWriter explicitly with Close
+	// to update the error.
 	w, err := c.ws.NextWriter(messageType)
 	if err == nil {
 		err = c.ws.WriteMessage(messageType, data)

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -24,11 +24,12 @@ var (
 	ErrNotDailed = errors.New("websocket not created yet, please call Dial()")
 	// retryClientErrors contains the list of client (4XX) errors that may
 	// become successful if the request is retried.
-	retryClientErrors = map[int]bool{404: true, 408: true, 425: true}
+	retryClientErrors = map[int]bool{408: true, 425: true}
 )
 
 // Conn contains the state needed to connect, reconnect, and send
 // messages.
+// Default values must be updated before calling `Dial`.
 type Conn struct {
 	// InitialInterval is the first interval at which the backoff starts
 	// running.
@@ -89,7 +90,7 @@ func NewConn() *Conn {
 // be called again if the connection needs to be recreated.
 //
 // The function returns an error if the url is invalid or if
-// a 4XX error (except 404, 408, 425) is received in the HTTP
+// a 4XX error (except 408 and 425) is received in the HTTP
 // response.
 func (c *Conn) Dial(address string, header http.Header) error {
 	u, err := url.ParseRequestURI(address)
@@ -165,8 +166,8 @@ func (c *Conn) CanConnect() bool {
 	return c.reconnections < c.MaxReconnectionsTotal
 }
 
-// Close closes the "stop" channel and the underlying
-// network connection.
+// Close closes the network connection and cleans up private
+// resources after the connection is done.
 func (c *Conn) Close() error {
 	c.isDialed = false
 	c.stop <- true

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -1,0 +1,159 @@
+// Package connection provides a Websocket that will automatically
+// reconnect if the connection is dropped.
+package connection
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/locate/static"
+)
+
+// ErrNotConnected is returned when the application tries to
+// read/write a message and the connection is closed.
+var ErrNotConnected = errors.New("websocket not connected")
+
+// Conn contains state needed to connect, reconnect, and send
+// messages.
+type Conn struct {
+	InitialInterval      time.Duration
+	RandomizationFactor  float64
+	Multiplier           float64
+	MaxInterval          time.Duration
+	MaxElapsedTime       time.Duration
+	MaxReconnectionsTime time.Duration
+	Factor               float64
+	Dialer               websocket.Dialer
+	ws                   *websocket.Conn
+	url                  string
+	header               http.Header
+	ticker               time.Ticker
+	mu                   sync.Mutex
+	reconnections        int
+	isConnected          bool
+}
+
+// NewConn creates a new Conn with default values and starts
+// a new goroutine to reset the number of disconnects followed
+// by reconnects per hour.
+func NewConn() *Conn {
+	c := &Conn{
+		InitialInterval:      static.BackoffInitialInterval,
+		RandomizationFactor:  static.BackoffRandomizationFactor,
+		Multiplier:           static.BackoffMultiplier,
+		MaxInterval:          static.BackoffMaxInterval,
+		MaxElapsedTime:       static.BackoffMaxElapsedTime,
+		MaxReconnectionsTime: static.MaxReconnectionsTime,
+		Dialer:               websocket.Dialer{},
+	}
+	c.ticker = *time.NewTicker(c.MaxReconnectionsTime)
+	go func(c *Conn) {
+		for {
+			<-c.ticker.C
+			c.mu.Lock()
+			c.resetReconnections()
+			c.mu.Unlock()
+		}
+	}(c)
+	return c
+}
+
+// Dial creates a new persistent client connection and sets
+// the necessary state for future reconnections.
+func (c *Conn) Dial(url string, header http.Header) {
+	c.url = url
+	c.header = header
+	c.connect()
+}
+
+// WriteMessage is a helper method for getting a writer using
+// NextWriter, writing the message and closing the writer.
+// If the write fails or a disconnect has been detected, it will
+// close and reconnect.
+func (c *Conn) WriteMessage(messageType int, data []byte) error {
+	if c.IsConnected() {
+		err := c.ws.WriteMessage(messageType, data)
+		if err != nil {
+			c.CloseAndReconnect()
+		}
+		return err
+	}
+	if c.canConnect() {
+		c.CloseAndReconnect()
+	}
+	return ErrNotConnected
+}
+
+// CloseAndReconnect calls Close and tries to reconnect.
+func (c *Conn) CloseAndReconnect() {
+	c.Close()
+	if c.canConnect() {
+		c.mu.Lock()
+		c.reconnections++
+		c.mu.Unlock()
+		c.connect()
+	}
+}
+
+// Close closes the underlying network connection without
+// sending or waiting for a close frame.
+func (c *Conn) Close() {
+	c.isConnected = false
+	c.ws.Close()
+}
+
+// IsConnected returns the WebSocket connection state.
+func (c *Conn) IsConnected() bool {
+	return c.isConnected
+}
+
+// resetReconnections sets the number of disconnects followed
+// by reconnects.
+func (c *Conn) resetReconnections() {
+	c.reconnections = 0
+}
+
+// canConnect checks whether it is possible to reconnect
+// given the recent number of attempts.
+func (c *Conn) canConnect() bool {
+	return c.reconnections < static.MaxReconnectionsTotal
+}
+
+// connect creates a new client connection. In case of failure,
+// it uses an exponential backoff to increase the duration of
+// retry attempts.
+func (c *Conn) connect() {
+	b := c.getBackoff()
+	ticker := backoff.NewTicker(b)
+
+	for range ticker.C {
+		ws, _, err := c.Dialer.Dial(c.url, c.header)
+		if err != nil {
+			log.Printf("could not establish a connection with %s (will retry), err: %v",
+				c.url, err)
+		} else {
+			c.ws = ws
+			c.isConnected = true
+			ticker.Stop()
+			log.Printf("successfully established a connection with %s", c.url)
+		}
+	}
+}
+
+// getBackoff returns a backoff implementation that increases the
+// backoff period for each retry attempt using a randomization function
+// that grows exponentially.
+func (c *Conn) getBackoff() *backoff.ExponentialBackOff {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = c.InitialInterval
+	b.RandomizationFactor = c.RandomizationFactor
+	b.Multiplier = c.Multiplier
+	b.MaxInterval = c.MaxInterval
+	b.MaxElapsedTime = c.MaxElapsedTime
+	return b
+}

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -66,9 +66,7 @@ func (c *Conn) Dial(url string, header http.Header) error {
 		defer c.ticker.Stop()
 		for {
 			<-c.ticker.C
-			c.mu.Lock()
 			c.resetReconnections()
-			c.mu.Unlock()
 		}
 	}(c)
 
@@ -110,12 +108,16 @@ func (c *Conn) IsConnected() bool {
 // resetReconnections sets the number of disconnects followed
 // by reconnects.
 func (c *Conn) resetReconnections() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.reconnections = 0
 }
 
 // canConnect checks whether it is possible to reconnect
 // given the recent number of attempts.
 func (c *Conn) canConnect() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.reconnections < static.MaxReconnectionsTotal
 }
 

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -1,0 +1,1 @@
+package connection

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -79,7 +79,7 @@ func Test_Dial_InvalidUrl(t *testing.T) {
 		},
 		{
 			name: "https",
-			url:  "https://127.0.0.1:46311/v2/heartbeat/",
+			url:  "https://127.0.0.2:1234/v2/heartbeat/",
 		},
 	}
 
@@ -133,12 +133,10 @@ func Test_WriteMessage(t *testing.T) {
 		{
 			name:       "success",
 			disconnect: false,
-			wantErr:    false,
 		},
 		{
 			name:       "disconnect-reconnect",
 			disconnect: true,
-			wantErr:    true,
 		},
 	}
 
@@ -211,7 +209,7 @@ func Test_CloseAndReconnect(t *testing.T) {
 	s := testdata.FakeServer(fh.Upgrade)
 	defer close(c, s)
 	// For testing, make this time window smaller.
-	c.MaxReconnectionsTime = 2 * time.Second
+	c.MaxReconnectionsTime = time.Second
 	c.Dial(s.URL, http.Header{})
 
 	for i := 0; i < static.MaxReconnectionsTotal; i++ {

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -80,17 +80,17 @@ func Test_WriteMessage(t *testing.T) {
 	tests := []struct {
 		name       string
 		disconnect bool
-		wantErr    error
+		wantErr    bool
 	}{
 		{
 			name:       "success",
 			disconnect: false,
-			wantErr:    nil,
+			wantErr:    false,
 		},
 		{
 			name:       "disconnect-reconnect",
 			disconnect: true,
-			wantErr:    ErrNotConnected,
+			wantErr:    true,
 		},
 	}
 
@@ -103,15 +103,15 @@ func Test_WriteMessage(t *testing.T) {
 			c.Dial(s.URL, http.Header{})
 
 			if tt.disconnect {
-				c.Close()
+				fh.Close()
 			}
 
 			// Write new message. If connection was closed, it should reconnect
 			// and return a write error.
 			err := c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
 
-			if err != tt.wantErr {
-				t.Errorf("WriteMessage() error; got: %v, want: %v", err, tt.wantErr)
+			if err == nil && tt.wantErr {
+				t.Error("Writing after a disconnect should return an error, close, and reconnect")
 			}
 
 			// Connection should be alive and write should succeed.

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -143,7 +143,7 @@ func Test_CloseAndReconnect(t *testing.T) {
 		}
 
 		if !c.IsConnected() {
-			t.Error("CloseAndReconnect() failed to reconnect")
+			t.Error("WriteMessage() failed to reconnect")
 		}
 
 		err = c.WriteMessage(websocket.TextMessage, []byte("Health message!"))

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -29,6 +29,45 @@ func Test_Dial(t *testing.T) {
 	}
 }
 
+func Test_Dial_ThenClose(t *testing.T) {
+	c := NewConn()
+	fh := testdata.FakeHandler{}
+	s := testdata.FakeServer(fh.Upgrade)
+	defer s.Close()
+
+	if err := c.Dial(s.URL, http.Header{}); err != nil {
+		t.Errorf("Dial() should have returned nil error, err: %v", err)
+	}
+
+	if !c.IsConnected() {
+		t.Error("Dial() error, not connected")
+	}
+
+	if err := c.Close(); err != nil {
+		t.Errorf("Close() should have returned nil error, err: %v", err)
+	}
+
+	if c.IsConnected() {
+		t.Error("Close() error, still connected")
+	}
+
+	if err := c.Dial(s.URL, http.Header{}); err != nil {
+		t.Errorf("Dial() should have returned nil error, err: %v", err)
+	}
+
+	if !c.IsConnected() {
+		t.Error("Dial() error, not connected")
+	}
+
+	if err := c.Close(); err != nil {
+		t.Errorf("Close() should have returned nil error, err: %v", err)
+	}
+
+	if c.IsConnected() {
+		t.Error("Close() error, still connected")
+	}
+}
+
 func Test_Dial_InvalidUrl(t *testing.T) {
 	tests := []struct {
 		name string

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -78,7 +78,7 @@ func Test_Dial_InvalidUrl(t *testing.T) {
 			url:  "foo",
 		},
 		{
-			name: "https",
+			name: "https-invalid-scheme",
 			url:  "https://127.0.0.2:1234/v2/heartbeat/",
 		},
 	}

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -23,10 +23,6 @@ func Test_Dial(t *testing.T) {
 		t.Errorf("Dial() should have returned nil error, err: %v", err)
 	}
 
-	if c.ws == nil {
-		t.Error("Dial() error, websocket is nil")
-	}
-
 	if !c.IsConnected() {
 		t.Error("Dial() error, not connected")
 	}

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -31,6 +31,33 @@ func Test_Dial(t *testing.T) {
 	}
 }
 
+func Test_Dial_InvalidUrl(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{
+			name: "malformed",
+			url:  "foo",
+		},
+		{
+			name: "https",
+			url:  "https://127.0.0.1:46311/v2/heartbeat/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewConn()
+			err := c.Dial(tt.url, http.Header{})
+
+			if err == nil {
+				t.Error("Dial() should return an error when given an invalid URL")
+			}
+		})
+	}
+}
+
 func Test_Dial_ServerDown(t *testing.T) {
 	c := NewConn()
 	defer c.Close()

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -1,1 +1,136 @@
 package connection
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/locate/static"
+)
+
+func Test_Dial(t *testing.T) {
+	c := NewConn()
+	s := fakeServer()
+	defer close(c, s)
+
+	c.Dial(s.URL, http.Header{})
+
+	if c.ws == nil {
+		t.Error("Dial() error, websocket is nil")
+	}
+
+	if !c.IsConnected() {
+		t.Error("Dial() error, not connected")
+	}
+}
+
+func Test_WriteMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		disconnect bool
+		wantErr    error
+	}{
+		{
+			name:       "success",
+			disconnect: false,
+			wantErr:    nil,
+		},
+		{
+			name:       "disconnect-reconnect",
+			disconnect: true,
+			wantErr:    ErrNotConnected,
+		},
+	}
+
+	for _, tt := range tests {
+		c := NewConn()
+		s := fakeServer()
+
+		c.Dial(s.URL, http.Header{})
+
+		if tt.disconnect {
+			c.Close()
+		}
+
+		// Write new message. If connection was closed, it should reconnect
+		// and return a write error.
+		err := c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
+
+		if err != tt.wantErr {
+			t.Errorf("WriteMessage() error; got: %v, want: %v", err, tt.wantErr)
+		}
+
+		// Connection should be alive and write should succeed.
+		err = c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
+		if err != nil {
+			t.Errorf("WriteMessage() should have succeeded; err: %v", err)
+		}
+
+		close(c, s)
+	}
+}
+
+func Test_CloseAndReconnect(t *testing.T) {
+	c := NewConn()
+	s := fakeServer()
+	defer close(c, s)
+	c.Dial(s.URL, http.Header{})
+
+	for i := 0; i < static.MaxReconnectionsTotal; i++ {
+		c.Close()
+		if c.IsConnected() {
+			t.Errorf("Close() failed to close connection")
+		}
+
+		c.reconnect()
+		if !c.IsConnected() {
+			t.Errorf("reconnect() failed to reconnect")
+		}
+
+		err := c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
+		if err != nil {
+			t.Errorf("WriteMessage() should succeed after reconnection; err: %v", err)
+		}
+	}
+
+	c.Close()
+	c.reconnect()
+	if c.IsConnected() {
+		t.Errorf("reconnect() should fail after maximum reconnections reached")
+	}
+	err := c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
+	if err == nil {
+		t.Errorf("WriteMessage() should fail while disconnected")
+	}
+}
+
+func fakeHandler(w http.ResponseWriter, r *http.Request) {
+	upgrader := websocket.Upgrader{}
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer c.Close()
+
+	for {
+		_, _, err := c.ReadMessage()
+		if err != nil {
+			return
+		}
+	}
+}
+
+func fakeServer() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/v2/heartbeat/", http.HandlerFunc(fakeHandler))
+	s := httptest.NewServer(mux)
+	s.URL = strings.Replace(s.URL, "http", "ws", 1) + "/v2/heartbeat/"
+	return s
+}
+
+func close(c *Conn, s *httptest.Server) {
+	c.Close()
+	s.Close()
+}

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -73,6 +73,18 @@ func Test_Dial_ServerDown(t *testing.T) {
 	}
 }
 
+func Test_Dial_BadRequest(t *testing.T) {
+	c := NewConn()
+	fh := testdata.FakeHandler{}
+	// This handler returns a 400 status code.
+	s := testdata.FakeServer(fh.BadUpgrade)
+	err := c.Dial(s.URL, http.Header{})
+
+	if err == nil {
+		t.Error("Dial() should fail when a 400 response status code is received")
+	}
+}
+
 func Test_WriteMessage(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -154,7 +154,7 @@ func Test_WriteMessage_ErrNotConnected(t *testing.T) {
 	// Shut server down so reconnection fails.
 	s.Close()
 
-	// We detect the connection has been disconnected through WriteMessage.
+	// Detect the connection has been disconnected through WriteMessage.
 	err := c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
 	if err == nil {
 		t.Error("Writing after a disconnect should return an error, close, and try to reconnect")
@@ -174,11 +174,12 @@ func Test_WriteMessage_ErrCannotReconnect(t *testing.T) {
 	defer c.Close()
 	fh := testdata.FakeHandler{}
 	s := testdata.FakeServer(fh.Upgrade)
+	defer s.Close()
 	c.Dial(s.URL, http.Header{})
 	// Close connection so writes fail.
 	fh.Close()
 
-	// We detect the connection has been disconnected through WriteMessage.
+	// Detect the connection has been disconnected through WriteMessage.
 	err := c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
 	if err == nil {
 		t.Error("Writing after a disconnect should return an error, close, and try to reconnect")

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -124,11 +124,11 @@ func Test_CloseAndReconnect(t *testing.T) {
 	c.Close()
 	c.reconnect()
 	if c.IsConnected() {
-		t.Errorf("reconnect() should fail after maximum reconnections reached")
+		t.Error("reconnect() should fail after maximum reconnections reached")
 	}
 	err := c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
 	if err == nil {
-		t.Errorf("WriteMessage() should fail while disconnected")
+		t.Error("WriteMessage() should fail while disconnected")
 	}
 
 	// It should reconnect again once the number of reconnections is reset.
@@ -136,7 +136,7 @@ func Test_CloseAndReconnect(t *testing.T) {
 	<-timer.C
 	c.reconnect()
 	if !c.IsConnected() {
-		t.Errorf("reconnect() failed to reconnect after resetReconnections()")
+		t.Error("reconnect() failed to reconnect after resetReconnections()")
 	}
 	err = c.WriteMessage(websocket.TextMessage, []byte("Health message!"))
 	if err != nil {

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -128,7 +128,6 @@ func Test_WriteMessage(t *testing.T) {
 	tests := []struct {
 		name       string
 		disconnect bool
-		wantErr    bool
 	}{
 		{
 			name:       "success",

--- a/connection/testdata/fakeserver.go
+++ b/connection/testdata/fakeserver.go
@@ -25,9 +25,9 @@ func (fh *FakeHandler) Upgrade(w http.ResponseWriter, r *http.Request) {
 	fh.conn, _ = upgrader.Upgrade(w, r, nil)
 }
 
-func (fh *FakeHandler) ReadError() error {
-	_, _, err := fh.conn.ReadMessage()
-	return err
+func (fh *FakeHandler) Read() ([]byte, error) {
+	_, msg, err := fh.conn.ReadMessage()
+	return msg, err
 }
 
 func (fh *FakeHandler) Close() {

--- a/connection/testdata/fakeserver.go
+++ b/connection/testdata/fakeserver.go
@@ -29,13 +29,6 @@ func (fh *FakeHandler) Upgrade(w http.ResponseWriter, r *http.Request) {
 	fh.conn, _ = upgrader.Upgrade(w, r, nil)
 }
 
-func (fh *FakeHandler) Read() ([]byte, error) {
-	fh.mu.Lock()
-	defer fh.mu.Unlock()
-	_, msg, err := fh.conn.ReadMessage()
-	return msg, err
-}
-
 func (fh *FakeHandler) Close() {
 	fh.mu.Lock()
 	defer fh.mu.Unlock()

--- a/connection/testdata/fakeserver.go
+++ b/connection/testdata/fakeserver.go
@@ -29,6 +29,10 @@ func (fh *FakeHandler) Upgrade(w http.ResponseWriter, r *http.Request) {
 	fh.conn, _ = upgrader.Upgrade(w, r, nil)
 }
 
+func (fh *FakeHandler) BadUpgrade(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(400)
+}
+
 func (fh *FakeHandler) Read() ([]byte, error) {
 	fh.mu.Lock()
 	defer fh.mu.Unlock()

--- a/connection/testdata/fakeserver.go
+++ b/connection/testdata/fakeserver.go
@@ -1,0 +1,33 @@
+package testdata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+func FakeServer() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.Handle("/v2/heartbeat/", http.HandlerFunc(fakeHandler))
+	s := httptest.NewServer(mux)
+	s.URL = strings.Replace(s.URL, "http", "ws", 1) + "/v2/heartbeat/"
+	return s
+}
+
+func fakeHandler(w http.ResponseWriter, r *http.Request) {
+	upgrader := websocket.Upgrader{}
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer c.Close()
+
+	for {
+		_, _, err := c.ReadMessage()
+		if err != nil {
+			return
+		}
+	}
+}

--- a/connection/testdata/fakeserver.go
+++ b/connection/testdata/fakeserver.go
@@ -8,26 +8,28 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-func FakeServer() *httptest.Server {
+func FakeServer(handler func(http.ResponseWriter, *http.Request)) *httptest.Server {
 	mux := http.NewServeMux()
-	mux.Handle("/v2/heartbeat/", http.HandlerFunc(fakeHandler))
+	mux.Handle("/v2/heartbeat/", http.HandlerFunc(handler))
 	s := httptest.NewServer(mux)
 	s.URL = strings.Replace(s.URL, "http", "ws", 1) + "/v2/heartbeat/"
 	return s
 }
 
-func fakeHandler(w http.ResponseWriter, r *http.Request) {
-	upgrader := websocket.Upgrader{}
-	c, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		return
-	}
-	defer c.Close()
+type FakeHandler struct {
+	conn *websocket.Conn
+}
 
-	for {
-		_, _, err := c.ReadMessage()
-		if err != nil {
-			return
-		}
-	}
+func (fh *FakeHandler) Upgrade(w http.ResponseWriter, r *http.Request) {
+	upgrader := websocket.Upgrader{}
+	fh.conn, _ = upgrader.Upgrade(w, r, nil)
+}
+
+func (fh *FakeHandler) ReadError() error {
+	_, _, err := fh.conn.ReadMessage()
+	return err
+}
+
+func (fh *FakeHandler) Close() {
+	fh.conn.Close()
 }

--- a/connection/testdata/fakeserver.go
+++ b/connection/testdata/fakeserver.go
@@ -29,6 +29,13 @@ func (fh *FakeHandler) Upgrade(w http.ResponseWriter, r *http.Request) {
 	fh.conn, _ = upgrader.Upgrade(w, r, nil)
 }
 
+func (fh *FakeHandler) Read() ([]byte, error) {
+	fh.mu.Lock()
+	defer fh.mu.Unlock()
+	_, msg, err := fh.conn.ReadMessage()
+	return msg, err
+}
+
 func (fh *FakeHandler) Close() {
 	fh.mu.Lock()
 	defer fh.mu.Unlock()

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	cloud.google.com/go/secretmanager v1.4.0
 	github.com/apex/log v1.9.0
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/go-test/deep v1.0.8
 	github.com/googleapis/gax-go v1.0.3
 	github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -9,15 +9,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var readDeadline = static.DefaultWebsocketReadDeadline
+var readDeadline = static.WebsocketReadDeadline
 
 // Heartbeat implements /v2/heartbeat requests.
 // It starts a new persistent connection and a new goroutine
 // to read incoming messages.
 func (c *Client) Heartbeat(rw http.ResponseWriter, req *http.Request) {
 	upgrader := websocket.Upgrader{
-		ReadBufferSize:  static.DefaultWebsocketBufferSize,
-		WriteBufferSize: static.DefaultWebsocketBufferSize,
+		ReadBufferSize:  static.WebsocketBufferSize,
+		WriteBufferSize: static.WebsocketBufferSize,
 	}
 	ws, err := upgrader.Upgrade(rw, req, nil)
 	if err != nil {
@@ -40,11 +40,6 @@ func read(ws *websocket.Conn) {
 		}
 		if message != nil {
 			setReadDeadline(ws)
-
-			// When a new message (ping) is received, send a pong
-			// back to let the peer know that the connection is
-			// still alive.
-			ws.WriteControl(websocket.PongMessage, nil, time.Now().Add(time.Second))
 
 			// Save message in Redis.
 		}

--- a/static/configs.go
+++ b/static/configs.go
@@ -9,20 +9,20 @@ import (
 // Constants used by the locate service, clients, and target servers accepting
 // access tokens issued by the locate service.
 const (
-	IssuerLocate                   = "locate"
-	AudienceLocate                 = "locate"
-	IssuerMonitoring               = "monitoring"
-	SubjectMonitoring              = "monitoring"
-	WebsocketBufferSize            = 1 << 10 // 1024 bytes.
-	WebsocketReadDeadline          = 30 * time.Second
-	BackoffInitialInterval         = 5 * time.Second
-	BackoffRandomizationFactor     = 0.5
-	BackoffMultiplier              = 1.5
-	BackoffMaxInterval             = time.Hour
-	BackoffMaxElapsedTime          = 0
-	MaxReconnectionsTotal      int = 10
-	MaxReconnectionsTime           = time.Hour
-	HeartbeatPeriod                = 10 * time.Second
+	IssuerLocate               = "locate"
+	AudienceLocate             = "locate"
+	IssuerMonitoring           = "monitoring"
+	SubjectMonitoring          = "monitoring"
+	WebsocketBufferSize        = 1 << 10 // 1024 bytes.
+	WebsocketReadDeadline      = 30 * time.Second
+	BackoffInitialInterval     = 5 * time.Second
+	BackoffRandomizationFactor = 0.5
+	BackoffMultiplier          = 1.5
+	BackoffMaxInterval         = time.Hour
+	BackoffMaxElapsedTime      = 0
+	MaxReconnectionsTotal      = 10
+	MaxReconnectionsTime       = time.Hour
+	HeartbeatPeriod            = 10 * time.Second
 )
 
 // URL creates inline url.URLs.

--- a/static/configs.go
+++ b/static/configs.go
@@ -15,7 +15,7 @@ const (
 	SubjectMonitoring          = "monitoring"
 	WebsocketBufferSize        = 1 << 10 // 1024 bytes.
 	WebsocketReadDeadline      = 30 * time.Second
-	BackoffInitialInterval     = 5 * time.Second
+	BackoffInitialInterval     = time.Second
 	BackoffRandomizationFactor = 0.5
 	BackoffMultiplier          = 2
 	BackoffMaxInterval         = time.Hour

--- a/static/configs.go
+++ b/static/configs.go
@@ -9,20 +9,20 @@ import (
 // Constants used by the locate service, clients, and target servers accepting
 // access tokens issued by the locate service.
 const (
-	IssuerLocate               = "locate"
-	AudienceLocate             = "locate"
-	IssuerMonitoring           = "monitoring"
-	SubjectMonitoring          = "monitoring"
-	WebsocketBufferSize        = 1 << 10 // 1024 bytes.
-	WebsocketReadDeadline      = 30 * time.Second
-	BackoffInitialInterval     = 5 * time.Second
-	BackoffRandomizationFactor = 0.5
-	BackoffMultiplier          = 1.5
-	BackoffMaxInterval         = time.Hour
-	BackoffMaxElapsedTime      = 0
-	MaxReconnectionsTotal      = 10
-	MaxReconnectionsTime       = time.Hour
-	HeartbeatPeriod            = 10 * time.Second
+	IssuerLocate                   = "locate"
+	AudienceLocate                 = "locate"
+	IssuerMonitoring               = "monitoring"
+	SubjectMonitoring              = "monitoring"
+	WebsocketBufferSize            = 1 << 10 // 1024 bytes.
+	WebsocketReadDeadline          = 30 * time.Second
+	BackoffInitialInterval         = 5 * time.Second
+	BackoffRandomizationFactor     = 0.5
+	BackoffMultiplier              = 1.5
+	BackoffMaxInterval             = time.Hour
+	BackoffMaxElapsedTime          = 0
+	MaxReconnectionsTotal      int = 10
+	MaxReconnectionsTime           = time.Hour
+	HeartbeatPeriod                = 10 * time.Second
 )
 
 // URL creates inline url.URLs.

--- a/static/configs.go
+++ b/static/configs.go
@@ -9,12 +9,20 @@ import (
 // Constants used by the locate service, clients, and target servers accepting
 // access tokens issued by the locate service.
 const (
-	IssuerLocate                 = "locate"
-	AudienceLocate               = "locate"
-	IssuerMonitoring             = "monitoring"
-	SubjectMonitoring            = "monitoring"
-	DefaultWebsocketBufferSize   = 1 << 10 // 1024 bytes.
-	DefaultWebsocketReadDeadline = 30 * time.Second
+	IssuerLocate               = "locate"
+	AudienceLocate             = "locate"
+	IssuerMonitoring           = "monitoring"
+	SubjectMonitoring          = "monitoring"
+	WebsocketBufferSize        = 1 << 10 // 1024 bytes.
+	WebsocketReadDeadline      = 30 * time.Second
+	BackoffInitialInterval     = 5 * time.Second
+	BackoffRandomizationFactor = 0.5
+	BackoffMultiplier          = 1.5
+	BackoffMaxInterval         = time.Hour
+	BackoffMaxElapsedTime      = 0
+	MaxReconnectionsTotal      = 10
+	MaxReconnectionsTime       = time.Hour
+	HeartbeatPeriod            = 10 * time.Second
 )
 
 // URL creates inline url.URLs.

--- a/static/configs.go
+++ b/static/configs.go
@@ -17,7 +17,7 @@ const (
 	WebsocketReadDeadline      = 30 * time.Second
 	BackoffInitialInterval     = 5 * time.Second
 	BackoffRandomizationFactor = 0.5
-	BackoffMultiplier          = 1.5
+	BackoffMultiplier          = 2
 	BackoffMaxInterval         = time.Hour
 	BackoffMaxElapsedTime      = 0
 	MaxReconnectionsTotal      = 10


### PR DESCRIPTION
This change adds the heartbeat service.

It uses the connection package to establish a persistent connection with the Locate and send heartbeat messages at periodic intervals. If the connection is dropped, it automatically tries to reconnect using an exponential backoff implementation for retries. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/64)
<!-- Reviewable:end -->
