### PR TITLE
Explicit network name in app.yaml

### DIFF
--- a/cloudbuild/app.yaml.template
+++ b/cloudbuild/app.yaml.template
@@ -12,8 +12,7 @@ resources:
   memory_gb: 8
 
 network:
-  name: default
-  subnetwork_name: default
+  name: locate
 
 automatic_scaling:
   max_num_instances: 20

--- a/cloudbuild/app.yaml.template
+++ b/cloudbuild/app.yaml.template
@@ -11,6 +11,10 @@ resources:
   cpu: 2
   memory_gb: 8
 
+network:
+  name: default
+  subnetwork_name: default
+
 automatic_scaling:
   max_num_instances: 20
   # Anecdotally, it seems to take roughly 5m for an instance to initialize


### PR DESCRIPTION
This change adds an explicit network name for the Locate app.yaml to resolve deployment failures in mlab-ns/production.

As well, since our primary projects (sandbox, staging, production) used very different default network configurations, this change depends on a new purpose-created `locate` VPC network in each project. For example:

```
gcloud --project mlab-sandbox compute networks create locate --subnet-mode=auto --bgp-routing-mode=regional
gcloud --project mlab-sandbox compute firewall-rules create locate-allow-internal --network locate --allow tcp,udp,icmp --source-ranges 0.0.0.0/0
gcloud --project mlab-sandbox compute firewall-rules create locate-allow-ssh --network locate --allow tcp:22,tcp:3389,icmp
```

These changes were necessary b/c during a routine deployment the mlab-ns deployment failed for an unexpected error related to the default "Legacy mode" network:

```
Step #1: ERROR: (gcloud.app.deploy) Error Response: [13] Flex operation projects/mlab-ns/regions/us-central1/operations/38f421fe-2315-41ba-aa9e-1c355fb2729f error [INTERNAL]: An internal error occurred while processing task /app-engine-flex/insert_flex_deployment/flex_create_resources>2022-05-23T17:05:06.210Z86057.in.0: Request to https://compute.googleapis.com/compute/v1/projects/projects/mlab-ns/regions/us-central1/subnetworks/default?key failed, details: The resource 'projects/mlab-ns/regions/us-central1/subnetworks/default' was not found
Step #1: 2022/05/23 17:05:14 error: pid:12 code:1 err:exit status 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/67)
<!-- Reviewable:end -->
