### PR TITLE
Use /v2/priority resource to serve Locate V2 requests

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -167,7 +167,7 @@ func main() {
 	// Clients request access tokens for specific services.
 	mux.HandleFunc("/v2/nearest/", http.HandlerFunc(c.TranslatedQuery))
 	// REQUIRED: API keys parameters required for priority requests.
-	mux.HandleFunc("/v2/priority/nearest/", http.HandlerFunc(c.TranslatedQuery))
+	mux.HandleFunc("/v2/priority/nearest/", http.HandlerFunc(c.Nearest))
 	// Beta version of V2 nearest requests.
 	mux.HandleFunc("/v2beta2/nearest/", http.HandlerFunc(c.Nearest))
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -132,6 +132,10 @@ paths:
           description: datatype
           type: string
           required: true
+        - name: machine-type
+          in: query
+          description: The machine type, e.g., "physical" or "virtual".
+          type: string
       responses:
         '200':
           description: The result of the nearest request. Clients should use the


### PR DESCRIPTION
This PR updates the handler for the "/v2/priority/nearest" resource to be served by the Locate v2. It also updates the `openapi` configuration.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/79)
<!-- Reviewable:end -->
