### PR TITLE
Add @latest to Dockerfile.heartbeat

### DIFF
--- a/cmd/heartbeat/Dockerfile.heartbeat
+++ b/cmd/heartbeat/Dockerfile.heartbeat
@@ -4,7 +4,7 @@ RUN apk add git
 ADD . /go/src/github.com/m-lab/locate
 RUN go install -v \
     -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
-    github.com/m-lab/locate/cmd/heartbeat
+    github.com/m-lab/locate/cmd/heartbeat@latest
 
 # Now copy the resulting command into the minimal base image.
 FROM alpine:3.16


### PR DESCRIPTION
This PR adds the `@latest` to the `Dockerfile.heartbeat` path, which was removed when the prometheus flag was added.

Error [log](https://hub.docker.com/repository/registry-1.docker.io/measurementlab/heartbeat/builds/6985fa4c-4012-4689-b3e9-564da5772c46):
```
#13 0.406 fatal: not a git repository (or any of the parent directories): .git
#13 0.412 go: 'go install' requires a version when current directory is not in a module
#13 0.412 Try 'go install github.com/m-lab/locate/cmd/heartbeat@latest' to install the latest version
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/81)
<!-- Reviewable:end -->
