### PR TITLE
Fix dash URL in the static configuration

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -55,7 +55,7 @@ var Configs = map[string]Ports{
 		URL("wss", ":3010", "/ndt_protocol"),
 	},
 	"neubot/dash": {
-		URL("https", "", "/"),
+		URL("https", "", "/negotiate/dash"),
 	},
 	"wehe/replay": {
 		URL("wss", ":4443", "/v0/envelope/access"),

--- a/static/configs.go
+++ b/static/configs.go
@@ -55,7 +55,7 @@ var Configs = map[string]Ports{
 		URL("wss", ":3010", "/ndt_protocol"),
 	},
 	"neubot/dash": {
-		URL("wss", "", "/v0/envelope/access"),
+		URL("https", "", "/"),
 	},
 	"wehe/replay": {
 		URL("wss", ":4443", "/v0/envelope/access"),


### PR DESCRIPTION
neubot/dash currently still uses mlab-ns, but is migrating to locate. @bassosimone expressed a preference toward wrapping dash's endpoint with the access controller directly (rather than using the envelope sidecar mechanism) similarly to what ndt-server does.

DASH's test endpoints  (`/dash/download/<number_of_bytes>`) won't work unless the client has called `/negotiate/dash` first and has received a valid session ID, so securing `/negotiate/dash` makes sure that tests cannot be run without a valid access token.

This PR changes the static config for `neubot/dash` to provide the correct URL (`https://<server>/negotiate/dash?access_token=...`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/82)
<!-- Reviewable:end -->
