### PR TITLE
Make generated tokens unique

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/go-test/deep v1.0.8
 	github.com/gomodule/redigo v1.8.8
+	github.com/google/uuid v1.1.2
 	github.com/googleapis/gax-go v1.0.3
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -19,6 +20,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/rafaeljusto/redigomock v2.4.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
+	golang.org/x/net v0.0.0-20220325170049-de3da57026de
 	google.golang.org/api v0.74.0
 	google.golang.org/genproto v0.0.0-20220405205423-9d709892a2bf
 	gopkg.in/square/go-jose.v2 v2.6.0
@@ -68,7 +70,6 @@ require (
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.4.2 // indirect
-	golang.org/x/net v0.0.0-20220325170049-de3da57026de // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/go-test/deep v1.0.8
 	github.com/gomodule/redigo v1.8.8
-	github.com/google/uuid v1.1.2
+	github.com/google/uuid v1.3.0
 	github.com/googleapis/gax-go v1.0.3
 	github.com/gorilla/websocket v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,9 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v1.0.3 h1:9dMLqhaibYONnDRcnHdUs9P8Mw64jLlZTYlDe3leBtQ=
 github.com/googleapis/gax-go v1.0.3/go.mod h1:QyXYajJFdARxGzjwUfbDFIse7Spkw81SJ4LrBJXtlQ8=
 github.com/googleapis/gax-go/v2 v2.0.2/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=

--- a/go.sum
+++ b/go.sum
@@ -239,6 +239,7 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v1.0.3 h1:9dMLqhaibYONnDRcnHdUs9P8Mw64jLlZTYlDe3leBtQ=
 github.com/googleapis/gax-go v1.0.3/go.mod h1:QyXYajJFdARxGzjwUfbDFIse7Spkw81SJ4LrBJXtlQ8=

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -222,7 +222,7 @@ func (c *Client) populateURLs(targets []v2.Target, ports static.Ports, exp strin
 // the intended audience and the subject as the target service.
 func (c *Client) getAccessToken(machine, subject string) string {
 	// Create the token. The same access token is reused for every URL of a
-	// target machine.
+	// target port.
 	// A uuid is added to the claims so that each new token is unique.
 	cl := jwt.Claims{
 		Issuer:   static.IssuerLocate,

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/square/go-jose.v2/jwt"
 
@@ -220,12 +221,14 @@ func (c *Client) populateURLs(targets []v2.Target, ports static.Ports, exp strin
 // getAccessToken allocates a new access token using the given machine name as
 // the intended audience and the subject as the target service.
 func (c *Client) getAccessToken(machine, subject string) string {
-	// Create the token. The same access token is used for each target port.
+	// Create the token. A uuid is added to the claims so that each token is
+	// unique.
 	cl := jwt.Claims{
 		Issuer:   static.IssuerLocate,
 		Subject:  subject,
 		Audience: jwt.Audience{machine},
 		Expiry:   jwt.NewNumericDate(time.Now().Add(time.Minute)),
+		ID:       uuid.New().String(),
 	}
 	token, err := c.Sign(cl)
 	// Sign errors can only happen due to a misconfiguration of the key.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -221,14 +221,15 @@ func (c *Client) populateURLs(targets []v2.Target, ports static.Ports, exp strin
 // getAccessToken allocates a new access token using the given machine name as
 // the intended audience and the subject as the target service.
 func (c *Client) getAccessToken(machine, subject string) string {
-	// Create the token. A uuid is added to the claims so that each token is
-	// unique.
+	// Create the token. The same access token is reused for every URL of a
+	// target machine.
+	// A uuid is added to the claims so that each new token is unique.
 	cl := jwt.Claims{
 		Issuer:   static.IssuerLocate,
 		Subject:  subject,
 		Audience: jwt.Audience{machine},
 		Expiry:   jwt.NewNumericDate(time.Now().Add(time.Minute)),
-		ID:       uuid.New().String(),
+		ID:       uuid.NewString(),
 	}
 	token, err := c.Sign(cl)
 	// Sign errors can only happen due to a misconfiguration of the key.


### PR DESCRIPTION
This PR changes the token generation so that the `jwt.Claims.ID` field (which becomes `jti` in JWT) is populated with a new UUID each time.

This makes each generated token unique, which in turn makes them viable as "session IDs" for measurements that make multiple calls across different endpoints/servers, and potentially allows us to check if tokens are being misused.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/84)
<!-- Reviewable:end -->
