### PR TITLE
Add handler for Prometheus cronjob

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/m-lab/locate/heartbeat"
 	"github.com/m-lab/locate/metrics"
 	"github.com/m-lab/locate/static"
+	prom "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 var errFailedToLookupClient = errors.New("Failed to look up client location")
@@ -41,6 +42,7 @@ type Client struct {
 	Locator
 	LocatorV2
 	ClientLocator
+	Prom       prom.API
 	targetTmpl *template.Template
 }
 
@@ -68,25 +70,27 @@ func init() {
 }
 
 // NewClient creates a new client.
-func NewClient(project string, private Signer, locator Locator, locatorV2 LocatorV2, client ClientLocator) *Client {
+func NewClient(project string, private Signer, locator Locator, locatorV2 LocatorV2, client ClientLocator, prom prom.API) *Client {
 	return &Client{
 		Signer:        private,
 		project:       project,
 		Locator:       locator,
 		LocatorV2:     locatorV2,
 		ClientLocator: client,
+		Prom:          prom,
 		targetTmpl:    template.Must(template.New("name").Parse("{{.Experiment}}-{{.Machine}}{{.Host}}")),
 	}
 }
 
 // NewClientDirect creates a new client with a target template using only the target machine.
-func NewClientDirect(project string, private Signer, locator Locator, locatorV2 LocatorV2, client ClientLocator) *Client {
+func NewClientDirect(project string, private Signer, locator Locator, locatorV2 LocatorV2, client ClientLocator, prom prom.API) *Client {
 	return &Client{
 		Signer:        private,
 		project:       project,
 		Locator:       locator,
 		LocatorV2:     locatorV2,
 		ClientLocator: client,
+		Prom:          prom,
 		// Useful for the locatetest package when running a local server.
 		targetTmpl: template.Must(template.New("name").Parse("{{.Machine}}{{.Host}}")),
 	}

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/m-lab/locate/heartbeat"
 	"github.com/m-lab/locate/proxy"
 	"github.com/m-lab/locate/static"
+	prom "github.com/prometheus/client_golang/api/prometheus/v1"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -177,7 +178,7 @@ func TestClient_TranslatedQuery(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := clientgeo.NewAppEngineLocator()
-			c := NewClient(tt.project, tt.signer, tt.locator, &fakeLocatorV2{}, cl)
+			c := NewClient(tt.project, tt.signer, tt.locator, &fakeLocatorV2{}, cl, prom.NewAPI(nil))
 
 			mux := http.NewServeMux()
 			mux.HandleFunc("/v2/nearest/", c.TranslatedQuery)
@@ -358,7 +359,7 @@ func TestClient_Nearest(t *testing.T) {
 			if tt.cl == nil {
 				tt.cl = clientgeo.NewAppEngineLocator()
 			}
-			c := NewClient(tt.project, tt.signer, &fakeLocator{}, tt.locator, tt.cl)
+			c := NewClient(tt.project, tt.signer, &fakeLocator{}, tt.locator, tt.cl, prom.NewAPI(nil))
 
 			mux := http.NewServeMux()
 			mux.HandleFunc("/v2beta2/nearest/", c.Nearest)
@@ -412,7 +413,7 @@ func TestClient_Nearest(t *testing.T) {
 
 func TestNewClientDirect(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		c := NewClientDirect("fake-project", nil, nil, nil, nil)
+		c := NewClientDirect("fake-project", nil, nil, nil, nil, nil)
 		if c == nil {
 			t.Error("got nil client!")
 		}

--- a/handler/heartbeat_test.go
+++ b/handler/heartbeat_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/locate/clientgeo"
+	prom "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 func init() {
@@ -64,5 +65,5 @@ func TestClient_Heartbeat_Timeout(t *testing.T) {
 
 func fakeClient() *Client {
 	return NewClient("mlab-sandbox", &fakeSigner{}, &fakeLocator{}, &fakeLocatorV2{},
-		clientgeo.NewAppEngineLocator())
+		clientgeo.NewAppEngineLocator(), prom.NewAPI(nil))
 }

--- a/handler/monitoring_test.go
+++ b/handler/monitoring_test.go
@@ -16,6 +16,7 @@ import (
 	v2 "github.com/m-lab/locate/api/v2"
 	"github.com/m-lab/locate/clientgeo"
 	"github.com/m-lab/locate/static"
+	prom "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 func TestClient_Monitoring(t *testing.T) {
@@ -91,7 +92,7 @@ func TestClient_Monitoring(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := clientgeo.NewAppEngineLocator()
-			c := NewClient("mlab-sandbox", tt.signer, tt.locator, &fakeLocatorV2{}, cl)
+			c := NewClient("mlab-sandbox", tt.signer, tt.locator, &fakeLocatorV2{}, cl, prom.NewAPI(nil))
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/v2/monitoring/"+tt.path, nil)
 			req = req.Clone(controller.SetClaim(req.Context(), tt.claim))

--- a/handler/prometheus.go
+++ b/handler/prometheus.go
@@ -33,8 +33,6 @@ var (
 )
 
 // Prometheus is a handler that collects Prometheus health signals.
-// The requests are made through a job set up on Cloud Scheduler. The job
-// is acknowledged by means of an HTTP response code.
 func (c *Client) Prometheus(rw http.ResponseWriter, req *http.Request) {
 	hostnames, err := c.query(req.Context(), e2eQuery, e2eLabel, e2eFunction)
 	if err != nil {

--- a/handler/prometheus.go
+++ b/handler/prometheus.go
@@ -25,7 +25,7 @@ var (
 
 	// GMX query parameters.
 	gmxQuery = "gmx_machine_maintenance"
-	gmxLabel = model.LabelName("hostname")
+	gmxLabel = model.LabelName("machine")
 	// The machine is not in maintenance if the value = 0.
 	gmxFunction = func(v float64) bool {
 		return v == 0

--- a/handler/prometheus.go
+++ b/handler/prometheus.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/m-lab/locate/static"
+	prom "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+var (
+	timeout         = static.PrometheusCheckPeriod
+	errCouldNotCast = errors.New("could not cast metric to vector")
+
+	// End-to-end query parameters.
+	e2eQuery = "script_success"
+	e2eLabel = model.LabelName("fqdn")
+	// The script was successful if the value != 0.
+	e2eFunction = func(v float64) bool {
+		return v != 0
+	}
+
+	// GMX query parameters.
+	gmxQuery = "gmx_machine_maintenance"
+	gmxLabel = model.LabelName("hostname")
+	// The machine is not in maintenance if the value = 0.
+	gmxFunction = func(v float64) bool {
+		return v == 0
+	}
+)
+
+// Prometheus implements /v2/platform/prometheus requests.
+// The requests are made through a job set up on Cloud Scheduler. The job
+// is acknowledged by means of an HTTP response code in the range [200-299].
+// TODO(cristinaleon): add metrics to track Prometheus calls.
+func (c *Client) Prometheus(rw http.ResponseWriter, req *http.Request) {
+	hostnames, err := c.query(req.Context(), e2eQuery, e2eLabel, e2eFunction)
+	if err != nil {
+		rw.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	machines, err := c.query(req.Context(), gmxQuery, gmxLabel, gmxFunction)
+	if err != nil {
+		rw.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	c.UpdatePrometheus(hostnames, machines)
+	rw.WriteHeader(http.StatusOK)
+}
+
+// query performs the provided PromQL query.
+func (c *Client) query(ctx context.Context, query string, labelName model.LabelName, f func(v float64) bool) (map[string]bool, error) {
+	result, _, err := c.Prom.Query(ctx, query, time.Now(), prom.WithTimeout(timeout))
+	if err != nil {
+		return nil, err
+	}
+
+	vector, ok := result.(model.Vector)
+	if !ok {
+		return nil, errCouldNotCast
+	}
+
+	return getMetrics(vector, labelName, f), nil
+}
+
+// getMetrics returns a map of labels to bool values from a Vector, based on the function parameter.
+func getMetrics(vector model.Vector, labelName model.LabelName, f func(v float64) bool) map[string]bool {
+	metrics := map[string]bool{}
+
+	for _, elem := range vector {
+		label := string(elem.Metric[labelName])
+		value := float64(elem.Value)
+		metrics[label] = f(value)
+	}
+
+	return metrics
+}

--- a/handler/prometheus_test.go
+++ b/handler/prometheus_test.go
@@ -1,0 +1,263 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/m-lab/locate/heartbeat"
+	"github.com/m-lab/locate/heartbeat/heartbeattest"
+	prom "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+)
+
+func TestClient_Prometheus(t *testing.T) {
+	tests := []struct {
+		name string
+		prom prom.API
+		want int
+	}{
+		{
+			name: "success",
+			prom: &fakePromAPI{
+				queryResult: model.Vector{},
+			},
+			want: http.StatusOK,
+		},
+		{
+			name: "e2e error",
+			prom: &fakePromAPI{
+				queryErr:    e2eQuery,
+				queryResult: model.Vector{},
+			},
+			want: http.StatusAccepted,
+		},
+		{
+			name: "gmx error",
+			prom: &fakePromAPI{
+				queryErr:    gmxQuery,
+				queryResult: model.Vector{},
+			},
+			want: http.StatusAccepted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memorystore := heartbeattest.FakeMemorystoreClient
+			tracker := heartbeat.NewHeartbeatStatusTracker(&memorystore)
+			locator := heartbeat.NewServerLocator(tracker)
+			locator.StopImport()
+
+			c := &Client{
+				LocatorV2: locator,
+				Prom:      tt.prom,
+			}
+			rw := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/v2/platform/prometheus", nil)
+			c.Prometheus(rw, req)
+
+			if tt.want != rw.Code {
+				t.Errorf("Prometheus() expected status code: %d, got: %d", tt.want, rw.Code)
+			}
+		})
+	}
+}
+
+func TestClient_query(t *testing.T) {
+	tests := []struct {
+		name    string
+		prom    prom.API
+		query   string
+		label   model.LabelName
+		f       func(float64) bool
+		want    map[string]bool
+		wantErr bool
+	}{
+		{
+			name: "query-error",
+			prom: &fakePromAPI{
+				queryErr: "error",
+			},
+			query:   "error",
+			wantErr: true,
+		},
+		{
+			name: "cast-error",
+			prom: &fakePromAPI{
+				queryResult: model.Matrix{},
+			},
+			query:   "query",
+			wantErr: true,
+		},
+		{
+			name: "e2e",
+			prom: &fakePromAPI{
+				queryResult: model.Vector{
+					{
+						Metric: map[model.LabelName]model.LabelValue{
+							e2eLabel: "success",
+						},
+						Value: 1,
+					},
+					{
+						Metric: map[model.LabelName]model.LabelValue{
+							e2eLabel: "failure",
+						},
+						Value: 0,
+					},
+				},
+			},
+			query: e2eQuery,
+			label: e2eLabel,
+			f:     e2eFunction,
+			want: map[string]bool{
+				"success": true,
+				"failure": false,
+			},
+			wantErr: false,
+		},
+		{
+			name: "gmx",
+			prom: &fakePromAPI{
+				queryResult: model.Vector{
+					{
+						Metric: map[model.LabelName]model.LabelValue{
+							gmxLabel: "not-gmx",
+						},
+						Value: 0,
+					},
+					{
+						Metric: map[model.LabelName]model.LabelValue{
+							gmxLabel: "gmx",
+						},
+						Value: 1,
+					},
+				},
+			},
+			query: gmxQuery,
+			label: gmxLabel,
+			f:     gmxFunction,
+			want: map[string]bool{
+				"not-gmx": true,
+				"gmx":     false,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				Prom: tt.prom,
+			}
+
+			got, err := c.query(context.TODO(), tt.query, tt.label, tt.f)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Client.query() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Client.query() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+var errFakeQuery = errors.New("fake query error")
+
+type fakePromAPI struct {
+	queryErr    string
+	queryResult model.Value
+}
+
+func (p *fakePromAPI) Query(ctx context.Context, query string, ts time.Time, opts ...prom.Option) (model.Value, prom.Warnings, error) {
+	if query == p.queryErr {
+		return nil, prom.Warnings{}, errFakeQuery
+	}
+
+	return p.queryResult, prom.Warnings{}, nil
+}
+
+func (p *fakePromAPI) Alerts(ctx context.Context) (prom.AlertsResult, error) {
+	return prom.AlertsResult{}, nil
+}
+
+func (p *fakePromAPI) AlertManagers(ctx context.Context) (prom.AlertManagersResult, error) {
+	return prom.AlertManagersResult{}, nil
+}
+
+func (p *fakePromAPI) CleanTombstones(ctx context.Context) error {
+	return nil
+}
+
+func (p *fakePromAPI) Config(ctx context.Context) (prom.ConfigResult, error) {
+	return prom.ConfigResult{}, nil
+}
+
+func (p *fakePromAPI) DeleteSeries(ctx context.Context, matches []string, startTime, endTime time.Time) error {
+	return nil
+}
+
+func (p *fakePromAPI) Flags(ctx context.Context) (prom.FlagsResult, error) {
+	return prom.FlagsResult{}, nil
+}
+
+func (p *fakePromAPI) LabelNames(ctx context.Context, matches []string, startTime, endTime time.Time) ([]string, prom.Warnings, error) {
+	return []string{}, prom.Warnings{}, nil
+}
+
+func (p *fakePromAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time) (model.LabelValues, prom.Warnings, error) {
+	return model.LabelValues{}, prom.Warnings{}, nil
+}
+
+func (p *fakePromAPI) QueryRange(ctx context.Context, query string, r prom.Range, opts ...prom.Option) (model.Value, prom.Warnings, error) {
+	return nil, prom.Warnings{}, nil
+}
+
+func (p *fakePromAPI) QueryExemplars(ctx context.Context, query string, startTime, endTime time.Time) ([]prom.ExemplarQueryResult, error) {
+	return []prom.ExemplarQueryResult{}, nil
+}
+
+func (p *fakePromAPI) Buildinfo(ctx context.Context) (prom.BuildinfoResult, error) {
+	return prom.BuildinfoResult{}, nil
+}
+
+func (p *fakePromAPI) Runtimeinfo(ctx context.Context) (prom.RuntimeinfoResult, error) {
+	return prom.RuntimeinfoResult{}, nil
+}
+
+func (p *fakePromAPI) Series(ctx context.Context, matches []string, startTime, endTime time.Time) ([]model.LabelSet, prom.Warnings, error) {
+	return []model.LabelSet{}, prom.Warnings{}, nil
+}
+
+func (p *fakePromAPI) Snapshot(ctx context.Context, skipHead bool) (prom.SnapshotResult, error) {
+	return prom.SnapshotResult{}, nil
+}
+
+func (p *fakePromAPI) Rules(ctx context.Context) (prom.RulesResult, error) {
+	return prom.RulesResult{}, nil
+}
+
+func (p *fakePromAPI) Targets(ctx context.Context) (prom.TargetsResult, error) {
+	return prom.TargetsResult{}, nil
+}
+
+func (p *fakePromAPI) TargetsMetadata(ctx context.Context, matchTarget, metric, limit string) ([]prom.MetricMetadata, error) {
+	return []prom.MetricMetadata{}, nil
+}
+
+func (p *fakePromAPI) Metadata(ctx context.Context, metric, limit string) (map[string][]prom.Metadata, error) {
+	return map[string][]prom.Metadata{}, nil
+}
+
+func (p *fakePromAPI) TSDB(ctx context.Context) (prom.TSDBResult, error) {
+	return prom.TSDBResult{}, nil
+}
+
+func (p *fakePromAPI) WalReplay(ctx context.Context) (prom.WalReplayStatus, error) {
+	return prom.WalReplayStatus{}, nil
+}

--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -77,6 +77,13 @@ func (h *heartbeatStatusTracker) UpdateHealth(hostname string, hm v2.Health) err
 	return h.updateHealth(hostname, hm)
 }
 
+// UpdatePrometheus updates the v2.Prometheus field for all instances in Memorystore and
+// locally.
+// TODO(cristinaleon): Add functionality in next PR. This one is already becoming too big.
+func (h *heartbeatStatusTracker) UpdatePrometheus(hostnames, machines map[string]bool) error {
+	return nil
+}
+
 // Instances returns a mapping of all the v2.HeartbeatMessage instance keys to
 // their values.
 func (h *heartbeatStatusTracker) Instances() map[string]v2.HeartbeatMessage {

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -40,6 +40,7 @@ type site struct {
 type StatusTracker interface {
 	RegisterInstance(rm v2.Registration) error
 	UpdateHealth(hostname string, hm v2.Health) error
+	UpdatePrometheus(hostnames, machines map[string]bool) error
 	Instances() map[string]v2.HeartbeatMessage
 	StopImport()
 }

--- a/locatetest/locatetest.go
+++ b/locatetest/locatetest.go
@@ -15,6 +15,7 @@ import (
 	"github.com/m-lab/locate/clientgeo"
 	"github.com/m-lab/locate/handler"
 	"github.com/m-lab/locate/heartbeat"
+	prom "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 // Signer implements the Signer interface for unit tests.
@@ -70,7 +71,7 @@ func (l *LocatorV2) Nearest(service, typ string, lat, lon float64) ([]v2.Target,
 func NewLocateServer(loc *Locator) *httptest.Server {
 	// fake signer, fake locator.
 	s := &Signer{}
-	c := handler.NewClientDirect("fake-project", s, loc, &LocatorV2{}, &clientgeo.NullLocator{})
+	c := handler.NewClientDirect("fake-project", s, loc, &LocatorV2{}, &clientgeo.NullLocator{}, prom.NewAPI(nil))
 
 	// USER APIs
 	mux := http.NewServeMux()
@@ -88,7 +89,7 @@ func NewLocateServer(loc *Locator) *httptest.Server {
 func NewLocateServerV2(loc *LocatorV2) *httptest.Server {
 	// fake signer, fake locator.
 	s := &Signer{}
-	c := handler.NewClientDirect("fake-project", s, &Locator{}, loc, &clientgeo.NullLocator{})
+	c := handler.NewClientDirect("fake-project", s, &Locator{}, loc, &clientgeo.NullLocator{}, prom.NewAPI(nil))
 
 	// USER APIs
 	mux := http.NewServeMux()

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -44,6 +44,16 @@ var (
 		},
 	)
 
+	// PrometheusHealthCollectionDuration is a historgram that tracks the latency of the
+	// handler that collects Prometheus health signals.
+	PrometheusHealthCollectionDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "prometheus_health_collection_duration",
+			Help: "A histogram of request latencies to the Prometheus health signal handler.",
+		},
+		[]string{"code"},
+	)
+
 	// PortChecksTotal counts the number of port checks performed by the Heartbeat
 	// Service.
 	PortChecksTotal = promauto.NewCounterVec(

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -44,7 +44,7 @@ var (
 		},
 	)
 
-	// PrometheusHealthCollectionDuration is a historgram that tracks the latency of the
+	// PrometheusHealthCollectionDuration is a histogram that tracks the latency of the
 	// handler that collects Prometheus health signals.
 	PrometheusHealthCollectionDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -10,6 +10,7 @@ func TestLintMetrics(t *testing.T) {
 	RequestsTotal.WithLabelValues("type", "status")
 	AppEngineTotal.WithLabelValues("country")
 	CurrentHeartbeatConnections.Set(0)
+	PrometheusHealthCollectionDuration.WithLabelValues("code")
 	PortChecksTotal.WithLabelValues("status")
 	KubernetesRequestsTotal.WithLabelValues("status")
 	KubernetesRequestTimeHistogram.WithLabelValues("healthy")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -207,6 +207,19 @@ paths:
       tags:
         - platform
 
+  "/v2/platform/prometheus":
+    get:
+      description: |-
+        Platform-specific path.
+      operationId: "v2-platform-prometheus"
+      responses:
+        '200':
+          description: OK.
+      security:
+      - api_key: []
+      tags:
+        - platform
+
   "/v2/platform/monitoring/{name}/{type}":
     get:
       description: |-

--- a/static/configs.go
+++ b/static/configs.go
@@ -24,6 +24,7 @@ const (
 	MaxReconnectionsTime       = time.Hour
 	HeartbeatPeriod            = 10 * time.Second
 	MemorystoreExportPeriod    = 10 * time.Second
+	PrometheusCheckPeriod      = time.Minute
 	RedisKeyExpirySecs         = 30
 	EarthHalfCircumferenceKm   = 20038
 )


### PR DESCRIPTION
This PR adds a handler for /v2/platform/prometheus requests.

The handler is triggered by a [Cloud Scheduler](https://pantheon.corp.google.com/cloudscheduler?project=mlab-sandbox) job that runs every minute. The job does not interfere with the App Engine cron job configuration defined in [`mlab-ns`](https://github.com/m-lab/mlab-ns/blob/main/cron.yaml). It will also continue to work when the Locate moves to GKE.

The openapi configuration enforces the usage of an API Key to make requests..

The handler queries Prometheus for GMX and end-to-end metrics. It creates a map of label values (e.g., service hostname or machine name) to bool values (e.g., false if the script was unsuccessful or the machine is in maintenance, true otherwise) and passes the information to the [`heartbeatStatusTracker`](https://github.com/m-lab/locate/pull/86/files#diff-56a9f2247a896c0973e751da67a8ba079722d033c5e98fc11161d4cc2cde1319R80) to update Memorystore.

Note: the Memorystore functionality will be added in the next PR because this one is already becoming too large. That means coverage for the 3 uncovered lines will also be added then.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/86)
<!-- Reviewable:end -->
