### PR TITLE
Make Kubernetes metric error generic

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -7,15 +7,15 @@ options:
 
 steps:
 # Run unit tests for environment.
-# - name: gcr.io/$PROJECT_ID/golang-cbif:1.18
-#   env:
-#   - GONOPROXY=github.com/m-lab/go/*
-#   args:
-#   - go version
-#   - go get -v -t ./...
-#   - go vet ./...
-#   - go test ./... -race
-#   - go test -v ./...
+- name: gcr.io/$PROJECT_ID/golang-cbif:1.18
+  env:
+  - GONOPROXY=github.com/m-lab/go/*
+  args:
+  - go version
+  - go get -v -t ./...
+  - go vet ./...
+  - go test ./... -race
+  - go test -v ./...
 
 # Deployment of APIs in sandbox & staging & mlab-ns.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -7,15 +7,15 @@ options:
 
 steps:
 # Run unit tests for environment.
-- name: gcr.io/$PROJECT_ID/golang-cbif:1.18
-  env:
-  - GONOPROXY=github.com/m-lab/go/*
-  args:
-  - go version
-  - go get -v -t ./...
-  - go vet ./...
-  - go test ./... -race
-  - go test -v ./...
+# - name: gcr.io/$PROJECT_ID/golang-cbif:1.18
+#   env:
+#   - GONOPROXY=github.com/m-lab/go/*
+#   args:
+#   - go version
+#   - go get -v -t ./...
+#   - go vet ./...
+#   - go test ./... -race
+#   - go test -v ./...
 
 # Deployment of APIs in sandbox & staging & mlab-ns.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18

--- a/cmd/heartbeat/health/kubernetes-client.go
+++ b/cmd/heartbeat/health/kubernetes-client.go
@@ -103,7 +103,7 @@ func (c *KubernetesClient) isHealthy(ctx context.Context) bool {
 }
 
 func (c *KubernetesClient) isPodRunning(ctx context.Context) bool {
-	pod, err := c.clientset.CoreV1().Pods(c.namespace).Get(nil, c.pod, metav1.GetOptions{})
+	pod, err := c.clientset.CoreV1().Pods(c.namespace).Get(ctx, "hi", metav1.GetOptions{})
 	if err != nil {
 		log.Printf("%s: %v", errKubernetesAPI, err)
 		metrics.KubernetesRequestsTotal.WithLabelValues(unwrap(err)).Inc()

--- a/cmd/heartbeat/health/kubernetes-client.go
+++ b/cmd/heartbeat/health/kubernetes-client.go
@@ -160,7 +160,7 @@ func extractError(err error) string {
 	// For errors like "Get 'https://fake-url': context deadline exceeded",
 	// return the base error without the URL.
 	if len(parts) == 2 {
-		return parts[1]
+		return parts[len(parts)-1]
 	}
 
 	// For unrecognized error formats, return a static message.

--- a/cmd/heartbeat/health/kubernetes-client.go
+++ b/cmd/heartbeat/health/kubernetes-client.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"log"
 	"net/url"
 	"path"
 	"strconv"
@@ -15,6 +16,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
+
+var errKubernetesAPI = "error making request to Kubernetes API server"
 
 // KubernetesClient manages requests to the Kubernetes API server.
 type KubernetesClient struct {
@@ -101,7 +104,8 @@ func (c *KubernetesClient) isHealthy(ctx context.Context) bool {
 func (c *KubernetesClient) isPodRunning(ctx context.Context) bool {
 	pod, err := c.clientset.CoreV1().Pods(c.namespace).Get(ctx, c.pod, metav1.GetOptions{})
 	if err != nil {
-		metrics.KubernetesRequestsTotal.WithLabelValues(err.Error()).Inc()
+		log.Printf("%s: %v", errKubernetesAPI, err)
+		metrics.KubernetesRequestsTotal.WithLabelValues(errKubernetesAPI).Inc()
 		return true
 	}
 
@@ -117,7 +121,8 @@ func (c *KubernetesClient) isPodRunning(ctx context.Context) bool {
 func (c *KubernetesClient) isNodeReady(ctx context.Context) bool {
 	node, err := c.clientset.CoreV1().Nodes().Get(ctx, c.node, metav1.GetOptions{})
 	if err != nil {
-		metrics.KubernetesRequestsTotal.WithLabelValues(err.Error()).Inc()
+		log.Printf("%s: %v", errKubernetesAPI, err)
+		metrics.KubernetesRequestsTotal.WithLabelValues(errKubernetesAPI).Inc()
 		return true
 	}
 

--- a/cmd/heartbeat/health/kubernetes-client.go
+++ b/cmd/heartbeat/health/kubernetes-client.go
@@ -159,10 +159,5 @@ func extractError(err error) string {
 
 	// For errors like "Get 'https://fake-url': context deadline exceeded",
 	// return the base error without the URL.
-	if len(parts) == 2 {
-		return parts[len(parts)-1]
-	}
-
-	// For unrecognized error formats, return a static message.
-	return errKubernetesAPI
+	return parts[len(parts)-1]
 }

--- a/cmd/heartbeat/health/kubernetes-client.go
+++ b/cmd/heartbeat/health/kubernetes-client.go
@@ -151,13 +151,5 @@ func isInMaintenance(node *v1.Node) bool {
 // the Kubernetes API.
 func extractError(err error) string {
 	parts := strings.Split(err.Error(), ": ")
-
-	// For errors like "context deadline exceeded", return the error as is.
-	if len(parts) == 1 {
-		return err.Error()
-	}
-
-	// For errors like "Get 'https://fake-url': context deadline exceeded",
-	// return the base error without the URL.
 	return parts[len(parts)-1]
 }

--- a/cmd/heartbeat/health/kubernetes-client_test.go
+++ b/cmd/heartbeat/health/kubernetes-client_test.go
@@ -156,11 +156,6 @@ func Test_extractError(t *testing.T) {
 			err:  errors.New("Get 'https://api-platform-cluster.mlab-sandbox.measurementlab.net:6443/api/v1/namespaces/default/pods/ndt-virtual-7qzzs': context deadline exceeded"),
 			want: "context deadline exceeded",
 		},
-		{
-			name: "unrecognized-error-format",
-			err:  errors.New("error 1: error 2: error 3"),
-			want: errKubernetesAPI,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/heartbeat/health/kubernetes-client_test.go
+++ b/cmd/heartbeat/health/kubernetes-client_test.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"testing"
 
@@ -134,6 +135,37 @@ func TestKubernetesClient_isHealthy(t *testing.T) {
 			}
 			if got := c.isHealthy(context.Background()); got != tt.want {
 				t.Errorf("KubernetesClient.isHealthy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_extractError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "base-error-only",
+			err:  errors.New("context deadline exceeded"),
+			want: "context deadline exceeded",
+		},
+		{
+			name: "error-with-pod-info",
+			err:  errors.New("Get 'https://api-platform-cluster.mlab-sandbox.measurementlab.net:6443/api/v1/namespaces/default/pods/ndt-virtual-7qzzs': context deadline exceeded"),
+			want: "context deadline exceeded",
+		},
+		{
+			name: "unrecognized-error-format",
+			err:  errors.New("error 1: error 2: error 3"),
+			want: errKubernetesAPI,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractError(tt.err); got != tt.want {
+				t.Errorf("extractError() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/heartbeat/health/kubernetes-client_test.go
+++ b/cmd/heartbeat/health/kubernetes-client_test.go
@@ -156,6 +156,11 @@ func Test_extractError(t *testing.T) {
 			err:  errors.New("Get 'https://api-platform-cluster.mlab-sandbox.measurementlab.net:6443/api/v1/namespaces/default/pods/ndt-virtual-7qzzs': context deadline exceeded"),
 			want: "context deadline exceeded",
 		},
+		{
+			name: "unrecognized-error-format",
+			err:  errors.New("error 1: error 2: error 3"),
+			want: "error 3",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The current error status contains a URL like the following:

```
Get "https://api-platform-cluster.mlab-sandbox.measurementlab.net:6443/api/v1/namespaces/default/pods/ndt-virtual-7qzzs": context deadline exceeded
Get "https://api-platform-cluster.mlab-sandbox.measurementlab.net:6443/api/v1/namespaces/default/pods/ndt-virtual-7qzzs": http2: client connection lost
Get "https://api-platform-cluster.mlab-sandbox.measurementlab.net:6443/api/v1/namespaces/default/pods/ndt-virtual-d6zzj": context deadline exceeded
Get "https://api-platform-cluster.mlab-sandbox.measurementlab.net:6443/api/v1/namespaces/default/pods/ndt-virtual-d6zzj": http2: client connection lost
```

This PR makes the error for the metric generic and logs the more specific one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/88)
<!-- Reviewable:end -->
