### PR TITLE
Remove buckets from histogram metric

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -88,9 +88,8 @@ var (
 	// Service to the Kubernetes API server (in seconds).
 	KubernetesRequestTimeHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "heartbeat_kubernetes_request_time_histogram",
-			Help:    "Request time from the HBS to the Kubernetes API server (seconds)",
-			Buckets: []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			Name: "heartbeat_kubernetes_request_time_histogram",
+			Help: "Request time from the HBS to the Kubernetes API server (seconds)",
 		},
 		[]string{"healthy"},
 	)


### PR DESCRIPTION
This PR removes the predefined buckets from the Kubernetes duration histogram so that the results fall under their natural buckets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/89)
<!-- Reviewable:end -->
