### PR TITLE
Add 'experiment' label to heartbeat connections gauge

### DIFF
--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -28,7 +28,6 @@ func (c *Client) Heartbeat(rw http.ResponseWriter, req *http.Request) {
 		metrics.RequestsTotal.WithLabelValues("heartbeat", err.Error()).Inc()
 		return
 	}
-
 	metrics.RequestsTotal.WithLabelValues("heartbeat", "OK").Inc()
 	go c.handleHeartbeats(ws)
 }
@@ -58,8 +57,8 @@ func (c *Client) handleHeartbeats(ws *websocket.Conn) {
 
 			switch {
 			case hbm.Registration != nil:
-				c.RegisterInstance(*hbm.Registration)
 				hostname = hbm.Registration.Hostname
+				c.RegisterInstance(*hbm.Registration)
 				experiment = hbm.Registration.Experiment
 				metrics.CurrentHeartbeatConnections.WithLabelValues(experiment).Inc()
 			case hbm.Health != nil:

--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -43,7 +43,9 @@ func (c *Client) handleHeartbeats(ws *websocket.Conn) {
 		_, message, err := ws.ReadMessage()
 		if err != nil {
 			log.Errorf("read error: %v", err)
-			metrics.CurrentHeartbeatConnections.WithLabelValues(experiment).Dec()
+			if experiment != "" {
+				metrics.CurrentHeartbeatConnections.WithLabelValues(experiment).Dec()
+			}
 			return
 		}
 		if message != nil {

--- a/handler/heartbeat_test.go
+++ b/handler/heartbeat_test.go
@@ -10,9 +10,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/locate/clientgeo"
-	"github.com/m-lab/locate/connection/testdata"
-	"github.com/m-lab/locate/heartbeat"
-	"github.com/m-lab/locate/heartbeat/heartbeattest"
 	prom "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
@@ -69,22 +66,4 @@ func TestClient_Heartbeat_Timeout(t *testing.T) {
 func fakeClient() *Client {
 	return NewClient("mlab-sandbox", &fakeSigner{}, &fakeLocator{}, &fakeLocatorV2{},
 		clientgeo.NewAppEngineLocator(), prom.NewAPI(nil))
-}
-
-func TestClient_handleRegistration(t *testing.T) {
-	tracker := heartbeat.NewHeartbeatStatusTracker(&heartbeattest.FakeMemorystoreClient)
-	c := &Client{
-		LocatorV2: &heartbeat.Locator{
-			StatusTracker: tracker,
-		},
-	}
-	rm := testdata.FakeRegistration.Registration
-
-	gotHost, gotExp := c.handleRegistration(rm)
-	if gotHost != rm.Hostname {
-		t.Errorf("Client.handleRegistration() got Hostname = %v, want Hostname %v", gotHost, rm.Hostname)
-	}
-	if gotExp != rm.Experiment {
-		t.Errorf("Client.handleRegistration() got Experiment = %v, want Experiment %v", gotExp, rm.Experiment)
-	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -55,15 +55,6 @@ var (
 		[]string{"code"},
 	)
 
-	// HeartbeatRegistrationsTotal counts the total number of registration
-	HeartbeatRegistrationsTotal = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "heartbeat_registrations_total",
-			Help: "Number of heartbeat registration requests",
-		},
-		[]string{"experiment", "status"},
-	)
-
 	// PortChecksTotal counts the number of port checks performed by the Heartbeat
 	// Service.
 	PortChecksTotal = promauto.NewCounterVec(

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -37,11 +37,12 @@ var (
 	//
 	// Example usage:
 	// metrics.CurrentHeartbeatConnections.Inc()
-	CurrentHeartbeatConnections = promauto.NewGauge(
+	CurrentHeartbeatConnections = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "locate_current_heartbeat_connections",
 			Help: "Number of currently active Heartbeat connections.",
 		},
+		[]string{"experiment"},
 	)
 
 	// PrometheusHealthCollectionDuration is a histogram that tracks the latency of the
@@ -52,6 +53,15 @@ var (
 			Help: "A histogram of request latencies to the Prometheus health signal handler.",
 		},
 		[]string{"code"},
+	)
+
+	// HeartbeatRegistrationsTotal counts the total number of registration
+	HeartbeatRegistrationsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "heartbeat_registrations_total",
+			Help: "Number of heartbeat registration requests",
+		},
+		[]string{"experiment", "status"},
 	)
 
 	// PortChecksTotal counts the number of port checks performed by the Heartbeat

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -9,7 +9,7 @@ import (
 func TestLintMetrics(t *testing.T) {
 	RequestsTotal.WithLabelValues("type", "status")
 	AppEngineTotal.WithLabelValues("country")
-	CurrentHeartbeatConnections.Set(0)
+	CurrentHeartbeatConnections.WithLabelValues("experiment").Set(0)
 	PrometheusHealthCollectionDuration.WithLabelValues("code")
 	PortChecksTotal.WithLabelValues("status")
 	KubernetesRequestsTotal.WithLabelValues("status")


### PR DESCRIPTION
This PR adds a new "experiment" label to the heartbeat connections gauge. This will allow filtering of the number of expected connections on Grafana dashboards based on the experiment.

Example: https://grafana.mlab-sandbox.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5s&viewPanel=10


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/90)
<!-- Reviewable:end -->
