### PR TITLE
Install local path in Dockerfile.heartbeat

### DIFF
--- a/cmd/heartbeat/Dockerfile.heartbeat
+++ b/cmd/heartbeat/Dockerfile.heartbeat
@@ -2,9 +2,10 @@
 FROM golang:1.18.3-alpine3.16 AS build
 RUN apk add git
 ADD . /go/src/github.com/m-lab/locate
-RUN go install -v \
+WORKDIR /go/src/github.com/m-lab/locate
+RUN CGO_ENABLED=0 go install -v \
     -ldflags "-X github.com/m-lab/go/prometheusx.GitShortCommit=$(git log -1 --format=%h)" \
-    github.com/m-lab/locate/cmd/heartbeat@latest
+    ./cmd/heartbeat
 
 # Now copy the resulting command into the minimal base image.
 FROM alpine:3.16


### PR DESCRIPTION
Use the local path in `go install`.

This populates the `git_short_commit` metric.

https://prometheus-platform-cluster.mlab-sandbox.measurementlab.net/graph?g0.expr=git_short_commit%7Bcontainer%3D%22heartbeat%22%7D&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=2h

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/93)
<!-- Reviewable:end -->
