### PR TITLE
Add in-country biasing for Locate V2

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -56,7 +56,7 @@ type Locator interface {
 // LocatorV2 defines how the Nearest handler requests machines nearest to the
 // client.
 type LocatorV2 interface {
-	Nearest(service, typ string, lat, lon float64) ([]v2.Target, []url.URL, error)
+	Nearest(service, typ, country string, lat, lon float64) ([]v2.Target, []url.URL, error)
 	heartbeat.StatusTracker
 }
 
@@ -188,7 +188,8 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 
 	// Find the nearest targets using the client parameters.
 	t := req.URL.Query().Get("machine-type")
-	targets, urls, err := c.LocatorV2.Nearest(service, t, lat, lon)
+	country := req.Header.Get("X-AppEngine-Country")
+	targets, urls, err := c.LocatorV2.Nearest(service, t, country, lat, lon)
 	if err != nil {
 		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", http.StatusInternalServerError)
 		writeResult(rw, result.Error.Status, &result)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -61,7 +61,7 @@ type fakeLocatorV2 struct {
 	urls    []url.URL
 }
 
-func (l *fakeLocatorV2) Nearest(service, typ string, lat, lon float64) ([]v2.Target, []url.URL, error) {
+func (l *fakeLocatorV2) Nearest(service, typ, country string, lat, lon float64) ([]v2.Target, []url.URL, error) {
 	if l.err != nil {
 		return nil, nil, l.err
 	}

--- a/heartbeat/location_test.go
+++ b/heartbeat/location_test.go
@@ -420,7 +420,6 @@ func TestIsValidInstance(t *testing.T) {
 	tests := []struct {
 		name         string
 		typ          string
-		country      string
 		host         string
 		lat          float64
 		lon          float64

--- a/heartbeat/location_test.go
+++ b/heartbeat/location_test.go
@@ -415,7 +415,6 @@ func TestIsValidInstance(t *testing.T) {
 	validLat := 40.7667
 	validLon := -73.8667
 	validType := "virtual"
-	validCountry := "US"
 	validScore := float64(1)
 
 	tests := []struct {
@@ -436,7 +435,6 @@ func TestIsValidInstance(t *testing.T) {
 		{
 			name:         "0-health",
 			typ:          "virtual",
-			country:      validCountry,
 			host:         validHost,
 			lat:          validLat,
 			lon:          validLon,
@@ -450,7 +448,6 @@ func TestIsValidInstance(t *testing.T) {
 		{
 			name:         "prometheus-unhealthy",
 			typ:          "",
-			country:      validCountry,
 			host:         validHost,
 			lat:          validLat,
 			lon:          validLon,
@@ -467,7 +464,6 @@ func TestIsValidInstance(t *testing.T) {
 		{
 			name:         "invalid-host",
 			typ:          "virtual",
-			country:      validCountry,
 			host:         "invalid-host",
 			lat:          validLat,
 			lon:          validLon,
@@ -481,7 +477,6 @@ func TestIsValidInstance(t *testing.T) {
 		{
 			name:         "mismatched-type",
 			typ:          "virtual",
-			country:      validCountry,
 			host:         validHost,
 			lat:          validLat,
 			lon:          validLon,
@@ -495,7 +490,6 @@ func TestIsValidInstance(t *testing.T) {
 		{
 			name:         "invalid-service",
 			typ:          "virtual",
-			country:      validCountry,
 			host:         validHost,
 			lat:          validLat,
 			lon:          validLon,
@@ -509,7 +503,6 @@ func TestIsValidInstance(t *testing.T) {
 		{
 			name:         "success-same-type",
 			typ:          "virtual",
-			country:      validCountry,
 			host:         validHost,
 			lat:          validLat,
 			lon:          validLon,
@@ -529,7 +522,6 @@ func TestIsValidInstance(t *testing.T) {
 		{
 			name:         "success-no-type",
 			typ:          "",
-			country:      validCountry,
 			host:         validHost,
 			lat:          validLat,
 			lon:          validLon,
@@ -571,7 +563,7 @@ func TestIsValidInstance(t *testing.T) {
 				},
 				Prometheus: tt.prom,
 			}
-			got, gotHost, gotDist := isValidInstance("ndt/ndt7", tt.typ, tt.country, 43.1988, -75.3242, v)
+			got, gotHost, gotDist := isValidInstance("ndt/ndt7", tt.typ, 43.1988, -75.3242, v)
 
 			if got != tt.expected {
 				t.Errorf("isValidInstance() got: %t, want: %t", got, tt.expected)
@@ -791,17 +783,15 @@ func TestBiasedDistance(t *testing.T) {
 	tests := []struct {
 		name     string
 		country  string
-		v        v2.HeartbeatMessage
+		r        *v2.Registration
 		distance float64
 		want     float64
 	}{
 		{
 			name:    "empty-country",
 			country: "",
-			v: v2.HeartbeatMessage{
-				Registration: &v2.Registration{
-					CountryCode: "foo",
-				},
+			r: &v2.Registration{
+				CountryCode: "foo",
 			},
 			distance: 100,
 			want:     100,
@@ -809,10 +799,8 @@ func TestBiasedDistance(t *testing.T) {
 		{
 			name:    "unknown-country",
 			country: "ZZ",
-			v: v2.HeartbeatMessage{
-				Registration: &v2.Registration{
-					CountryCode: "foo",
-				},
+			r: &v2.Registration{
+				CountryCode: "foo",
 			},
 			distance: 100,
 			want:     100,
@@ -820,10 +808,8 @@ func TestBiasedDistance(t *testing.T) {
 		{
 			name:    "same-country",
 			country: "foo",
-			v: v2.HeartbeatMessage{
-				Registration: &v2.Registration{
-					CountryCode: "foo",
-				},
+			r: &v2.Registration{
+				CountryCode: "foo",
 			},
 			distance: 100,
 			want:     100,
@@ -831,10 +817,8 @@ func TestBiasedDistance(t *testing.T) {
 		{
 			name:    "different-country",
 			country: "bar",
-			v: v2.HeartbeatMessage{
-				Registration: &v2.Registration{
-					CountryCode: "foo",
-				},
+			r: &v2.Registration{
+				CountryCode: "foo",
 			},
 			distance: 100,
 			want:     200,
@@ -843,7 +827,7 @@ func TestBiasedDistance(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := biasedDistance(tt.country, tt.v, tt.distance)
+			got := biasedDistance(tt.country, tt.r, tt.distance)
 
 			if got != tt.want {
 				t.Errorf("biasedDistance() got: %f, want: %f", got, tt.want)

--- a/heartbeat/location_test.go
+++ b/heartbeat/location_test.go
@@ -239,6 +239,7 @@ func TestNearest(t *testing.T) {
 		name            string
 		service         string
 		typ             string
+		country         string
 		lat             float64
 		lon             float64
 		instances       []v2.HeartbeatMessage
@@ -250,6 +251,7 @@ func TestNearest(t *testing.T) {
 			name:            "NDT7-any-type",
 			service:         "ndt/ndt7",
 			typ:             "",
+			country:         "US",
 			lat:             43.1988,
 			lon:             -75.3242,
 			expectedTargets: []v2.Target{virtualTarget, physicalTarget},
@@ -260,6 +262,7 @@ func TestNearest(t *testing.T) {
 			name:            "NDT7-physical",
 			service:         "ndt/ndt7",
 			typ:             "physical",
+			country:         "US",
 			lat:             43.1988,
 			lon:             -75.3242,
 			expectedTargets: []v2.Target{physicalTarget},
@@ -270,6 +273,7 @@ func TestNearest(t *testing.T) {
 			name:            "NDT7-virtual",
 			service:         "ndt/ndt7",
 			typ:             "virtual",
+			country:         "US",
 			lat:             43.1988,
 			lon:             -75.3242,
 			expectedTargets: []v2.Target{virtualTarget},
@@ -280,6 +284,7 @@ func TestNearest(t *testing.T) {
 			name:            "wehe",
 			service:         "wehe/replay",
 			typ:             "",
+			country:         "US",
 			lat:             43.1988,
 			lon:             -75.3242,
 			expectedTargets: []v2.Target{weheTarget},

--- a/locatetest/locatetest.go
+++ b/locatetest/locatetest.go
@@ -55,7 +55,7 @@ type LocatorV2 struct {
 }
 
 // Nearest returns the pre-configured LocatorV2 Servers or Err.
-func (l *LocatorV2) Nearest(service, typ string, lat, lon float64) ([]v2.Target, []url.URL, error) {
+func (l *LocatorV2) Nearest(service, typ, country string, lat, lon float64) ([]v2.Target, []url.URL, error) {
 	if l.Err != nil {
 		return nil, nil, l.Err
 	}


### PR DESCRIPTION
This PR adds in-country biasing for the Locate V2.

App Engine returns a valid country code for over 99% of requests, so this implementation uses its `X-AppEngine-Country` request header to double the distance for instances in a different country.

If the country in the request is empty or unknown ("ZZ"), or if the instance is in the same country as the client, there is no change.

*Note: this is not urgent. It can wait until after the holidays.*

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/94)
<!-- Reviewable:end -->
