### PR TITLE
Add NearestOptions type

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -56,7 +56,7 @@ type Locator interface {
 // LocatorV2 defines how the Nearest handler requests machines nearest to the
 // client.
 type LocatorV2 interface {
-	Nearest(service, typ, country string, lat, lon float64) ([]v2.Target, []url.URL, error)
+	Nearest(service string, lat, lon float64, opts *heartbeat.NearestOptions) ([]v2.Target, []url.URL, error)
 	heartbeat.StatusTracker
 }
 
@@ -189,7 +189,8 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 	// Find the nearest targets using the client parameters.
 	t := req.URL.Query().Get("machine-type")
 	country := req.Header.Get("X-AppEngine-Country")
-	targets, urls, err := c.LocatorV2.Nearest(service, t, country, lat, lon)
+	opts := &heartbeat.NearestOptions{Type: t, Country: country}
+	targets, urls, err := c.LocatorV2.Nearest(service, lat, lon, opts)
 	if err != nil {
 		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", http.StatusInternalServerError)
 		writeResult(rw, result.Error.Status, &result)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -61,7 +61,7 @@ type fakeLocatorV2 struct {
 	urls    []url.URL
 }
 
-func (l *fakeLocatorV2) Nearest(service, typ, country string, lat, lon float64) ([]v2.Target, []url.URL, error) {
+func (l *fakeLocatorV2) Nearest(service string, lat, lon float64, opts *heartbeat.NearestOptions) ([]v2.Target, []url.URL, error) {
 	if l.err != nil {
 		return nil, nil, l.err
 	}

--- a/heartbeat/location_test.go
+++ b/heartbeat/location_test.go
@@ -310,7 +310,9 @@ func TestNearest(t *testing.T) {
 				locator.UpdateHealth(i.Registration.Hostname, *i.Health)
 			}
 
-			gotTargets, gotURLs, err := locator.Nearest(tt.service, tt.typ, "", tt.lat, tt.lon)
+			opts := &NearestOptions{Type: tt.typ, Country: ""}
+
+			gotTargets, gotURLs, err := locator.Nearest(tt.service, tt.lat, tt.lon, opts)
 
 			if !reflect.DeepEqual(gotTargets, tt.expectedTargets) {
 				t.Errorf("Nearest() targets got: %+v, want %+v", gotTargets, tt.expectedTargets)
@@ -394,7 +396,8 @@ func TestFilterSites(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := filterSites(tt.service, tt.typ, tt.country, tt.lat, tt.lon, instances)
+			opts := &NearestOptions{Type: tt.typ, Country: tt.country}
+			got := filterSites(tt.service, tt.lat, tt.lon, instances, opts)
 
 			sortSites(got)
 			for _, v := range got {
@@ -562,7 +565,8 @@ func TestIsValidInstance(t *testing.T) {
 				},
 				Prometheus: tt.prom,
 			}
-			got, gotHost, gotDist := isValidInstance("ndt/ndt7", tt.typ, 43.1988, -75.3242, v)
+			opts := &NearestOptions{Type: tt.typ}
+			got, gotHost, gotDist := isValidInstance("ndt/ndt7", 43.1988, -75.3242, v, opts)
 
 			if got != tt.expected {
 				t.Errorf("isValidInstance() got: %t, want: %t", got, tt.expected)

--- a/locatetest/locatetest.go
+++ b/locatetest/locatetest.go
@@ -55,7 +55,7 @@ type LocatorV2 struct {
 }
 
 // Nearest returns the pre-configured LocatorV2 Servers or Err.
-func (l *LocatorV2) Nearest(service, typ, country string, lat, lon float64) ([]v2.Target, []url.URL, error) {
+func (l *LocatorV2) Nearest(service string, lat, lon float64, opts *heartbeat.NearestOptions) ([]v2.Target, []url.URL, error) {
 	if l.Err != nil {
 		return nil, nil, l.Err
 	}


### PR DESCRIPTION
This change introduces a new parameter to the LocatorV2 interface Nearest method for providing multiple options. Rather than accepting separate parameters for "machine type", "country", and future parameters (e.g. sites), a single "opts" parameter is passed through to lower levels.

This change helps lay the groundwork for a `sites=a,b,c` parameter that limits the set of sites returned by the Locate service to those named.