### PR TITLE
Use Locate V2 to serve /v2/nearest requests in sandbox

### DIFF
--- a/locate.go
+++ b/locate.go
@@ -186,6 +186,11 @@ func main() {
 
 	// USER APIs
 	// Clients request access tokens for specific services.
+	if project == "mlab-sandbox" {
+		mux.HandleFunc("/v2/nearest/", http.HandlerFunc(c.Nearest))
+	} else {
+		mux.HandleFunc("/v2/nearest/", http.HandlerFunc(c.TranslatedQuery))
+	}
 	mux.HandleFunc("/v2/nearest/", http.HandlerFunc(c.TranslatedQuery))
 	// REQUIRED: API keys parameters required for priority requests.
 	mux.HandleFunc("/v2/priority/nearest/", http.HandlerFunc(c.TranslatedQuery))

--- a/locate.go
+++ b/locate.go
@@ -191,7 +191,6 @@ func main() {
 	} else {
 		mux.HandleFunc("/v2/nearest/", http.HandlerFunc(c.TranslatedQuery))
 	}
-	mux.HandleFunc("/v2/nearest/", http.HandlerFunc(c.TranslatedQuery))
 	// REQUIRED: API keys parameters required for priority requests.
 	mux.HandleFunc("/v2/priority/nearest/", http.HandlerFunc(c.TranslatedQuery))
 	// Beta version of V2 nearest requests.

--- a/locate.go
+++ b/locate.go
@@ -186,6 +186,7 @@ func main() {
 
 	// USER APIs
 	// Clients request access tokens for specific services.
+	// TODO(cristinaleon): remove project names in code.
 	if project == "mlab-sandbox" {
 		mux.HandleFunc("/v2/nearest/", http.HandlerFunc(c.Nearest))
 	} else {


### PR DESCRIPTION
Changes tested with these URLs:

-  https://locate-dot-mlab-sandbox.appspot.com/v2/nearest/demo1/ndtm
- https://locate-dot-mlab-sandbox.appspot.com/v2/nearest/ndt/ndt7


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/96)
<!-- Reviewable:end -->
