### PR TITLE
Add locate_version parameter to output urls

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -104,12 +104,14 @@ func NewClientDirect(project string, private Signer, locator Locator, locatorV2 
 
 func extraParams(raw url.Values, version string) url.Values {
 	v := url.Values{}
+	// Add client parameters.
 	for key := range raw {
 		if strings.HasPrefix(key, "client_") {
 			// note: we only use the first value.
 			v.Set(key, raw.Get(key))
 		}
 	}
+	// Add Locate Service version.
 	v.Set("locate_version", version)
 	return v
 }


### PR DESCRIPTION
Results with the `locate_version` parameter appended at the end can be seen in sandbox (e.g., https://locate-dot-mlab-sandbox.appspot.com/v2/nearest/ndt/ndt7) 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/97)
<!-- Reviewable:end -->
