### PR TITLE
Allow site filter query parameters

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -190,9 +190,11 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// Find the nearest targets using the client parameters.
-	t := req.URL.Query().Get("machine-type")
+	q := req.URL.Query()
+	t := q.Get("machine-type")
 	country := req.Header.Get("X-AppEngine-Country")
-	opts := &heartbeat.NearestOptions{Type: t, Country: country}
+	sites := q["site"]
+	opts := &heartbeat.NearestOptions{Type: t, Country: country, Sites: sites}
 	targets, urls, err := c.LocatorV2.Nearest(service, lat, lon, opts)
 	if err != nil {
 		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", http.StatusInternalServerError)


### PR DESCRIPTION
This change enables the site filter query option. With this change clients can specify a set of sites returned in the results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/99)
<!-- Reviewable:end -->
