### PR TITLE
Modify health count metric

### DIFF
--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -163,6 +163,10 @@ func (h *heartbeatStatusTracker) importMemorystore() {
 	}
 }
 
+// updateMetrics updates a Prometheus Gauge with the number of healthy instances per
+// experiment.
+// Note that if an experiment is deleted (i.e., there are no more experiment instances),
+// the metric will still report the last known count.
 func (h *heartbeatStatusTracker) updateMetrics() {
 	healthy := make(map[string]float64)
 	for _, instance := range h.instances {

--- a/heartbeat/heartbeat_test.go
+++ b/heartbeat/heartbeat_test.go
@@ -294,36 +294,3 @@ func TestGetPrometheusMessage(t *testing.T) {
 		})
 	}
 }
-
-func TestPromNumericStatus(t *testing.T) {
-	tests := []struct {
-		name string
-		pm   *v2.Prometheus
-		want float64
-	}{
-		{
-			name: "true",
-			pm: &v2.Prometheus{
-				Health: true,
-			},
-			want: 1,
-		},
-		{
-			name: "false",
-			pm: &v2.Prometheus{
-				Health: false,
-			},
-			want: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := promNumericStatus(tt.pm)
-
-			if got != tt.want {
-				t.Errorf("promNumericStatus() got: %v, want: %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -118,11 +118,7 @@ func filterSites(service string, lat, lon float64, instances map[string]v2.Heart
 // isValidInstance returns whether a v2.HeartbeatMessage signals a valid
 // instance that can serve a request given its parameters.
 func isValidInstance(service string, lat, lon float64, v v2.HeartbeatMessage, opts *NearestOptions) (bool, host.Name, float64) {
-	if v.Registration == nil || v.Health == nil || v.Health.Score == 0 {
-		return false, host.Name{}, 0
-	}
-
-	if v.Prometheus != nil && !v.Prometheus.Health {
+	if !isHealthy(v) {
 		return false, host.Name{}, 0
 	}
 
@@ -151,6 +147,18 @@ func isValidInstance(service string, lat, lon float64, v v2.HeartbeatMessage, op
 	}
 
 	return true, machineName, distance
+}
+
+func isHealthy(v v2.HeartbeatMessage) bool {
+	if v.Registration == nil || v.Health == nil || v.Health.Score == 0 {
+		return false
+	}
+
+	if v.Prometheus != nil && !v.Prometheus.Health {
+		return false
+	}
+
+	return true
 }
 
 // contains reports whether the given string array contains the given value.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -45,26 +45,6 @@ var (
 		[]string{"experiment"},
 	)
 
-	// HeartbeatHealthStatus exposes the health status received from the
-	// Heartbeat Service.
-	HeartbeatHealthStatus = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "heartbeat_health_status",
-			Help: "Health status received from the Heartbeat Service.",
-		},
-		[]string{"hostname"},
-	)
-
-	// PrometheusHealthStatus exposes the health status collected from
-	// Prometheus.
-	PrometheusHealthStatus = promauto.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "prometheus_health_status",
-			Help: "Health status collected from Prometheus.",
-		},
-		[]string{"hostname"},
-	)
-
 	// LocateHealthStatus exposes the health status collected by the Locate Service.
 	LocateHealthStatus = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -71,7 +71,7 @@ var (
 			Name: "locate_health_status",
 			Help: "Health status collected by the Locate Service.",
 		},
-		[]string{"hostname"},
+		[]string{"experiment"},
 	)
 
 	// PrometheusHealthCollectionDuration is a histogram that tracks the latency of the

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -65,6 +65,15 @@ var (
 		[]string{"hostname"},
 	)
 
+	// LocateHealthStatus exposes the health status collected by the Locate Service.
+	LocateHealthStatus = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "locate_health_status",
+			Help: "Health status collected by the Locate Service.",
+		},
+		[]string{"hostname"},
+	)
+
 	// PrometheusHealthCollectionDuration is a histogram that tracks the latency of the
 	// handler that collects Prometheus health signals.
 	PrometheusHealthCollectionDuration = promauto.NewHistogramVec(

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -12,6 +12,7 @@ func TestLintMetrics(t *testing.T) {
 	CurrentHeartbeatConnections.WithLabelValues("experiment").Set(0)
 	HeartbeatHealthStatus.WithLabelValues("hostname").Set(0)
 	PrometheusHealthStatus.WithLabelValues("hostname").Set(0)
+	LocateHealthStatus.WithLabelValues("experiment").Set(0)
 	PrometheusHealthCollectionDuration.WithLabelValues("code")
 	PortChecksTotal.WithLabelValues("status")
 	KubernetesRequestsTotal.WithLabelValues("status")

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -10,8 +10,6 @@ func TestLintMetrics(t *testing.T) {
 	RequestsTotal.WithLabelValues("type", "status")
 	AppEngineTotal.WithLabelValues("country")
 	CurrentHeartbeatConnections.WithLabelValues("experiment").Set(0)
-	HeartbeatHealthStatus.WithLabelValues("hostname").Set(0)
-	PrometheusHealthStatus.WithLabelValues("hostname").Set(0)
 	LocateHealthStatus.WithLabelValues("experiment").Set(0)
 	PrometheusHealthCollectionDuration.WithLabelValues("code")
 	PortChecksTotal.WithLabelValues("status")


### PR DESCRIPTION
This PR removes the `locate_health_status` and `prometheus_health_status` metrics and combines them into one `locate_health_status` metric that uses the experiment as the label.

It also removes a flaky test (`TestStopImport`).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/100)
<!-- Reviewable:end -->
