### PR TITLE
Remove in-country biasing

### DIFF
--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -94,7 +94,7 @@ func filterSites(service string, lat, lon float64, instances map[string]v2.Heart
 		s, ok := m[r.Site]
 		if !ok {
 			s = &site{
-				distance:     biasedDistance(opts.Country, r, distance),
+				distance:     distance,
 				registration: *r,
 				machines:     make([]machine, 0),
 			}


### PR DESCRIPTION
This PR temporarily removes the in-country biasing since it is superseding user-provided parameters. 

It will be added back as a complement to the user-provided parameters after the rollout analyses are complete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/104)
<!-- Reviewable:end -->
