### PR TITLE
Remove flaky test

### DIFF
--- a/handler/heartbeat_test.go
+++ b/handler/heartbeat_test.go
@@ -3,37 +3,11 @@ package handler
 import (
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"runtime"
 	"testing"
-	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/m-lab/locate/clientgeo"
 	prom "github.com/prometheus/client_golang/api/prometheus/v1"
 )
-
-func init() {
-	readDeadline = 50 * time.Millisecond
-}
-
-func mustSetupTest(t testing.TB) (*Client, *websocket.Conn, func(tb testing.TB)) {
-	c := fakeClient()
-	s := httptest.NewServer(http.HandlerFunc(c.Heartbeat))
-	u, _ := url.Parse(s.URL)
-	u.Scheme = "ws"
-	dialer := websocket.Dialer{}
-	ws, _, err := dialer.Dial(u.String(), http.Header{})
-	if err != nil {
-		s.Close()
-		t.Fatalf("failed to establish a connection, err: %v", err)
-	}
-
-	return c, ws, func(t testing.TB) {
-		s.Close()
-		ws.Close()
-	}
-}
 
 func TestClient_Heartbeat_Error(t *testing.T) {
 	rw := httptest.NewRecorder()
@@ -45,21 +19,6 @@ func TestClient_Heartbeat_Error(t *testing.T) {
 
 	if rw.Code != http.StatusBadRequest {
 		t.Errorf("Heartbeat() wrong status code; got %d, want %d", rw.Code, http.StatusBadRequest)
-	}
-}
-
-func TestClient_Heartbeat_Timeout(t *testing.T) {
-	_, _, teardown := mustSetupTest(t)
-	defer teardown(t)
-
-	// The read loop runs in a separate goroutine, so we wait for it to exit.
-	// It will exit if there are no new messages within the read deadline.
-	before := runtime.NumGoroutine()
-	timer := time.NewTimer(2 * readDeadline)
-	<-timer.C
-	after := runtime.NumGoroutine()
-	if after >= before {
-		t.Errorf("Heartbeat() goroutine did not exit; got: %d, want: <%d", after, before)
 	}
 }
 


### PR DESCRIPTION
This PR removes a flaky test that waits a certain amount of time to confirm that a goroutine has exited. It will be replaced by a better test soon.

Note: there are no remaining similar tests in this repo 👼.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/105)
<!-- Reviewable:end -->
