### PR TITLE
Removes reduced probability for sites hnd06 and gru05

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -93,11 +93,9 @@ var SiteProbability = map[string]float64{
 	"del03": 0.1,  // virtual site
 	"dfw09": 0.1,  // virtual site
 	"fra07": 0.1,  // virtual site
-	"gru05": 0.1,  // virtual site
 	"hel01": 0.1,  // virtual site
 	"hkg04": 0.1,  // virtual site
 	"hnd01": 0.05, // 0.05
-	"hnd06": 0.1,  // virtual site
 	"iad07": 0.1,  // virtual site
 	"icn01": 0.1,  // virtual site
 	"kix01": 0.1,  // virtual site


### PR DESCRIPTION
We are going to continue experimenting with virtual-only metros, adding these two metros Sao Paulo (gru) and Tokyo (hnd) to the ongoing experiment in bom. Part of this will be treating the virtual sites in these metros like phyiscal site, 100% probability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/107)
<!-- Reviewable:end -->
