### PR TITLE
Add lock for concurrent reading of health information

### DIFF
--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -85,8 +85,8 @@ func (h *heartbeatStatusTracker) UpdateHealth(hostname string, hm v2.Health) err
 // UpdatePrometheus updates the v2.Prometheus field for the instances.
 func (h *heartbeatStatusTracker) UpdatePrometheus(hostnames, machines map[string]bool) error {
 	var err error
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	for _, instance := range h.instances {
 		pm := constructPrometheusMessage(instance, hostnames, machines)
@@ -153,8 +153,6 @@ func (h *heartbeatStatusTracker) updatePrometheusMessage(instance v2.HeartbeatMe
 	}
 
 	// Update locally.
-	h.mu.Lock()
-	defer h.mu.Unlock()
 	instance.Prometheus = pm
 	h.instances[hostname] = instance
 	return nil

--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -173,7 +173,6 @@ func (h *heartbeatStatusTracker) importMemorystore() {
 // the metric will still report the last known count.
 func (h *heartbeatStatusTracker) updateMetrics() {
 	healthy := h.getHealthy()
-
 	for experiment, count := range healthy {
 		metrics.LocateHealthStatus.WithLabelValues(experiment).Set(count)
 	}

--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -161,9 +161,9 @@ func (h *heartbeatStatusTracker) updatePrometheusMessage(instance v2.HeartbeatMe
 func (h *heartbeatStatusTracker) importMemorystore() {
 	values, err := h.GetAll()
 
-	h.mu.Lock()
-	defer h.mu.Unlock()
 	if err == nil {
+		h.mu.Lock()
+		defer h.mu.Unlock()
 		h.instances = values
 		h.updateMetrics()
 	}


### PR DESCRIPTION
There is locking for writing, but not for reading health information. The library has a special [`RLock`](https://pkg.go.dev/sync#RWMutex.RLock) to use for reading.

This PR fixes this error stack found in the logs:
```
DEFAULT 2023-01-19T14:45:31Z fatal error: concurrent map iteration and map write
DEFAULT 2023-01-19T14:45:31Z
DEFAULT 2023-01-19T14:45:31Z goroutine 3477 [running]:
DEFAULT 2023-01-19T14:45:31Z runtime.throw({0xd13b91?, 0xe6?})
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/runtime/panic.go:992 +0x71 fp=0xc000281720 sp=0xc0002816f0 pc=0x439ed1
DEFAULT 2023-01-19T14:45:31Z runtime.mapiternext(0xbcb4e0?)
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/runtime/map.go:871 +0x4eb fp=0xc000281790 sp=0xc000281720 pc=0x411bab
DEFAULT 2023-01-19T14:45:31Z github.com/m-lab/locate/heartbeat.(*heartbeatStatusTracker).Instances(0xc00017e040)
DEFAULT 2023-01-19T14:45:31Z /go/src/github.com/m-lab/locate/heartbeat/heartbeat.go:107 +0x99 fp=0xc000281840 sp=0xc000281790 pc=0xa98959
DEFAULT 2023-01-19T14:45:31Z github.com/m-lab/locate/heartbeat.(*Locator).Nearest(0xc004cb4870?, {0xc0000404f8, 0x8}, 0xc?, 0xc0001fe930?, 0x6cf100?)
DEFAULT 2023-01-19T14:45:31Z /go/src/github.com/m-lab/locate/heartbeat/location.go:67 +0x43 fp=0xc0002818b0 sp=0xc000281840 pc=0xa997a3
DEFAULT 2023-01-19T14:45:31Z github.com/m-lab/locate/handler.(*Client).Nearest(0xc00036c150, {0xe21220, 0xc00037e0e0}, 0xc004003000)
DEFAULT 2023-01-19T14:45:31Z /go/src/github.com/m-lab/locate/handler/handler.go:196 +0x54a fp=0xc0002819f0 sp=0xc0002818b0 pc=0xb0d0ca
DEFAULT 2023-01-19T14:45:31Z github.com/m-lab/locate/handler.(*Client).Nearest-fm({0xe21220?, 0xc00037e0e0?}, 0x0?)
DEFAULT 2023-01-19T14:45:31Z <autogenerated>:1 +0x3c fp=0xc000281a20 sp=0xc0002819f0 pc=0xb163fc
DEFAULT 2023-01-19T14:45:31Z net/http.HandlerFunc.ServeHTTP(0x7fd1e4c41758?, {0xe21220?, 0xc00037e0e0?}, 0x40f1a5?)
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/net/http/server.go:2084 +0x2f fp=0xc000281a48 sp=0xc000281a20 pc=0x6cd90f
DEFAULT 2023-01-19T14:45:31Z net/http.(*ServeMux).ServeHTTP(0xc004138259?, {0xe21220, 0xc00037e0e0}, 0xc004003000)
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/net/http/server.go:2462 +0x149 fp=0xc000281a98 sp=0xc000281a48 pc=0x6cf2a9
DEFAULT 2023-01-19T14:45:31Z net/http.serverHandler.ServeHTTP({0xc0045053b0?}, {0xe21220, 0xc00037e0e0}, 0xc004003000)
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/net/http/server.go:2916 +0x43b fp=0xc000281b58 sp=0xc000281a98 pc=0x6d0efb
DEFAULT 2023-01-19T14:45:31Z net/http.(*conn).serve(0xc000d37180, {0xe21d48, 0xc000129e90})
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/net/http/server.go:1966 +0x5d7 fp=0xc000281fb8 sp=0xc000281b58 pc=0x6cc3b7
DEFAULT 2023-01-19T14:45:31Z net/http.(*Server).Serve.func3()
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/net/http/server.go:3071 +0x2e fp=0xc000281fe0 sp=0xc000281fb8 pc=0x6d184e
DEFAULT 2023-01-19T14:45:31Z runtime.goexit()
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc000281fe8 sp=0xc000281fe0 pc=0x46c641
DEFAULT 2023-01-19T14:45:31Z created by net/http.(*Server).Serve
DEFAULT 2023-01-19T14:45:31Z /usr/local/go/src/net/http/server.go:3071 +0x4db
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/108)
<!-- Reviewable:end -->
