### PR TITLE
Adjust cool down period and target CPU

### DIFF
--- a/cloudbuild/app.yaml.template
+++ b/cloudbuild/app.yaml.template
@@ -18,9 +18,9 @@ network:
 
 automatic_scaling:
   max_num_instances: 20
-  # Anecdotally, it seems to take roughly 5m for an instance to initialize
-  # fully.
-  cool_down_period_sec: 300
+  cool_down_period_sec: 600
+  cpu_utilization:
+    target_utilization: 0.3
 
 env_variables:
   LEGACY_SERVER: https://{{PROJECT}}.appspot.com


### PR DESCRIPTION
The target CPU is currently set to the default (0.5), which is causing App Engine to constantly upscale and downscale instances. This PR decreases the target CPU to 0.3, so there are more instances available and upscaling is needed less frequently.

![Screenshot 2023-01-26 12 12 44 PM](https://user-images.githubusercontent.com/21001496/214903258-ce0a9329-92e0-47c9-adf1-8891a9cdaf91.png)

The PR also increases the cool down period to 10 minutes to avoid readiness errors when a new instance is created.
https://prometheus.mlab-oti.measurementlab.net/graph?g0.expr=locate_requests_total%7Binstance%3D%22aef-locate-20230120t215558-tm9d%22%7D&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h38m34s975ms&g0.end_input=2023-01-26%2000%3A06%3A04&g0.moment_input=2023-01-26%2000%3A06%3A04

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/109)
<!-- Reviewable:end -->
