### PR TITLE
Revert target CPU and add more metrics

### DIFF
--- a/cloudbuild/app.yaml.template
+++ b/cloudbuild/app.yaml.template
@@ -17,7 +17,7 @@ network:
     - 9090/tcp
 
 automatic_scaling:
-  max_num_instances: 20
+  max_num_instances: 40
   cool_down_period_sec: 300
 
 env_variables:

--- a/cloudbuild/app.yaml.template
+++ b/cloudbuild/app.yaml.template
@@ -19,8 +19,6 @@ network:
 automatic_scaling:
   max_num_instances: 20
   cool_down_period_sec: 300
-  cpu_utilization:
-    target_utilization: 0.3
 
 env_variables:
   LEGACY_SERVER: https://{{PROJECT}}.appspot.com

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -175,7 +175,8 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 		status := http.StatusServiceUnavailable
 		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", status)
 		writeResult(rw, result.Error.Status, &result)
-		metrics.RequestsTotal.WithLabelValues("nearest", http.StatusText(result.Error.Status)).Inc()
+		metrics.RequestsTotal.WithLabelValues("nearest", "client location",
+			http.StatusText(result.Error.Status)).Inc()
 		return
 	}
 
@@ -185,7 +186,8 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 	if errLat != nil || errLon != nil {
 		result.Error = v2.NewError("client", errFailedToLookupClient.Error(), http.StatusInternalServerError)
 		writeResult(rw, result.Error.Status, &result)
-		metrics.RequestsTotal.WithLabelValues("nearest", http.StatusText(result.Error.Status)).Inc()
+		metrics.RequestsTotal.WithLabelValues("nearest", "parse client location",
+			http.StatusText(result.Error.Status)).Inc()
 		return
 	}
 
@@ -197,7 +199,8 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", http.StatusInternalServerError)
 		writeResult(rw, result.Error.Status, &result)
-		metrics.RequestsTotal.WithLabelValues("nearest", http.StatusText(result.Error.Status)).Inc()
+		metrics.RequestsTotal.WithLabelValues("nearest", "server location",
+			http.StatusText(result.Error.Status)).Inc()
 		return
 	}
 
@@ -205,7 +208,7 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 	c.populateURLs(targets, urls, experiment, "v2", req.Form)
 	result.Results = targets
 	writeResult(rw, http.StatusOK, &result)
-	metrics.RequestsTotal.WithLabelValues("nearest", http.StatusText(http.StatusOK)).Inc()
+	metrics.RequestsTotal.WithLabelValues("nearest", "", http.StatusText(http.StatusOK)).Inc()
 }
 
 // checkClientLocation looks up the client location and copies the location

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -208,7 +208,7 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 	c.populateURLs(targets, urls, experiment, "v2", req.Form)
 	result.Results = targets
 	writeResult(rw, http.StatusOK, &result)
-	metrics.RequestsTotal.WithLabelValues("nearest", "", http.StatusText(http.StatusOK)).Inc()
+	metrics.RequestsTotal.WithLabelValues("nearest", "success", http.StatusText(http.StatusOK)).Inc()
 }
 
 // checkClientLocation looks up the client location and copies the location

--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -25,10 +25,11 @@ func (c *Client) Heartbeat(rw http.ResponseWriter, req *http.Request) {
 	ws, err := upgrader.Upgrade(rw, req, nil)
 	if err != nil {
 		log.Errorf("failed to establish a connection: %v", err)
-		metrics.RequestsTotal.WithLabelValues("heartbeat", "establish connection", err.Error()).Inc()
+		metrics.RequestsTotal.WithLabelValues("heartbeat", "establish connection",
+			"error upgrading the HTTP server connection to the WebSocket protocol").Inc()
 		return
 	}
-	metrics.RequestsTotal.WithLabelValues("heartbeat", "", "OK").Inc()
+	metrics.RequestsTotal.WithLabelValues("heartbeat", "establish connection", "OK").Inc()
 	go c.handleHeartbeats(ws)
 }
 

--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -25,10 +25,10 @@ func (c *Client) Heartbeat(rw http.ResponseWriter, req *http.Request) {
 	ws, err := upgrader.Upgrade(rw, req, nil)
 	if err != nil {
 		log.Errorf("failed to establish a connection: %v", err)
-		metrics.RequestsTotal.WithLabelValues("heartbeat", err.Error()).Inc()
+		metrics.RequestsTotal.WithLabelValues("heartbeat", "establish connection", err.Error()).Inc()
 		return
 	}
-	metrics.RequestsTotal.WithLabelValues("heartbeat", "OK").Inc()
+	metrics.RequestsTotal.WithLabelValues("heartbeat", "", "OK").Inc()
 	go c.handleHeartbeats(ws)
 }
 

--- a/heartbeat/heartbeat.go
+++ b/heartbeat/heartbeat.go
@@ -161,12 +161,16 @@ func (h *heartbeatStatusTracker) updatePrometheusMessage(instance v2.HeartbeatMe
 func (h *heartbeatStatusTracker) importMemorystore() {
 	values, err := h.GetAll()
 
-	if err == nil {
-		h.mu.Lock()
-		defer h.mu.Unlock()
-		h.instances = values
-		h.updateMetrics()
+	if err != nil {
+		metrics.ImportMemorystoreTotal.WithLabelValues(err.Error()).Inc()
+		return
 	}
+
+	metrics.ImportMemorystoreTotal.WithLabelValues("OK").Inc()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.instances = values
+	h.updateMetrics()
 }
 
 // updateMetrics updates a Prometheus Gauge with the number of healthy instances per

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -58,7 +58,7 @@ var (
 	// the data in Memorystore.
 	ImportMemorystoreTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "locate_import_memotystore_total",
+			Name: "locate_import_memorystore_total",
 			Help: "Number of times the Locate Service has imported the data in Memorystore.",
 		},
 		[]string{"status"},

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -16,7 +16,7 @@ var (
 			Name: "locate_requests_total",
 			Help: "Number of requests served by the Locate service.",
 		},
-		[]string{"type", "status"},
+		[]string{"type", "condition", "status"},
 	)
 
 	// AppEngineTotal counts the number of times App Engine headers are
@@ -52,6 +52,16 @@ var (
 			Help: "Health status collected by the Locate Service.",
 		},
 		[]string{"experiment"},
+	)
+
+	// ImportMemorystoreTotal counts the number of times the Locate Service has imported
+	// the data in Memorystore.
+	ImportMemorystoreTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "locate_import_memotystore_total",
+			Help: "Number of times the Locate Service has imported the data in Memorystore.",
+		},
+		[]string{"status"},
 	)
 
 	// PrometheusHealthCollectionDuration is a histogram that tracks the latency of the

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func TestLintMetrics(t *testing.T) {
-	RequestsTotal.WithLabelValues("type", "status")
+	RequestsTotal.WithLabelValues("type", "condition", "status")
 	AppEngineTotal.WithLabelValues("country")
 	CurrentHeartbeatConnections.WithLabelValues("experiment").Set(0)
 	LocateHealthStatus.WithLabelValues("experiment").Set(0)
+	ImportMemorystoreTotal.WithLabelValues("status")
 	PrometheusHealthCollectionDuration.WithLabelValues("code")
 	PortChecksTotal.WithLabelValues("status")
 	KubernetesRequestsTotal.WithLabelValues("status")


### PR DESCRIPTION
This PR reverts the target CPU utilization to the default value it was using [before](https://github.com/m-lab/locate/pull/109/files) (i.e., [0.5](https://cloud.google.com/appengine/docs/flexible/reference/app-yaml?tab=go#automatic_scaling)) and it adds new metrics and labels.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/111)
<!-- Reviewable:end -->
