### PR TITLE
Update site probabilities after cloud 1st experiments

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -83,51 +83,59 @@ var LegacyServices = map[string]string{
 // the current number of requests. The default value is 1.0.
 // TODO(github.com/m-lab/locate/issues/92): Make this dynamic.
 var SiteProbability = map[string]float64{
-	"ams10": 0.1, // virtual site
-	"bom01": 0.5,
-	"bom02": 0.5,
-	"bru06": 0.1,  // virtual site
-	"cgk01": 0.1,  // virtual site
-	"chs01": 0.1,  // virtual site
-	"cmh01": 0.1,  // virtual site
-	"del03": 0.1,  // virtual site
-	"dfw09": 0.1,  // virtual site
-	"fra07": 0.1,  // virtual site
-	"hel01": 0.1,  // virtual site
-	"hkg04": 0.1,  // virtual site
+	"ams10": 0.2, // virtual site
+	"bom01": 0.1,
+	"bom02": 0.1,
+	"bru06": 0.2, // virtual site
+	"cgk01": 0.2, // virtual site
+	"chs01": 0.2, // virtual site
+	"cmh01": 0.2, // virtual site
+	"del03": 0.2, // virtual site
+	"dfw09": 0.2, // virtual site
+	"fra07": 0.2, // virtual site
+	"gru01": 0.1,
+	"gru02": 0.1,
+	"gru03": 0.1,
+	"gru04": 0.1,
+	"hel01": 0.2,  // virtual site
+	"hkg04": 0.2,  // virtual site
 	"hnd01": 0.05, // 0.05
-	"iad07": 0.1,  // virtual site
-	"icn01": 0.1,  // virtual site
-	"kix01": 0.1,  // virtual site
-	"las01": 0.1,  // virtual site
-	"lax07": 0.1,  // virtual site
+	"hnd02": 0.1,
+	"hnd03": 0.1,
+	"hnd04": 0.1,
+	"hnd05": 0.1,
+	"iad07": 0.2, // virtual site
+	"icn01": 0.2, // virtual site
+	"kix01": 0.2, // virtual site
+	"las01": 0.2, // virtual site
+	"lax07": 0.2, // virtual site
 	"lga1t": 0.5,
-	"lhr09": 0.1, // virtual site
+	"lhr09": 0.2, // virtual site
 	"lis01": 0.5,
 	"lju01": 0.5,
-	"mad07": 0.1, // virtual site
-	"mel01": 0.1, // virtual site
-	"mil08": 0.1, // virtual site
-	"oma01": 0.1, // virtual site
-	"ord07": 0.1, // virtual site
-	"par08": 0.1, // virtual site
-	"pdx01": 0.1, // virtual site
-	"scl05": 0.1, // virtual site
-	"sea09": 0.1, // virtual site
-	"sin02": 0.1, // virtual site
-	"slc01": 0.1, // virtual site
-	"syd07": 0.1, // virtual site
-	"tpe02": 0.1, // virtual site
+	"mad07": 0.2, // virtual site
+	"mel01": 0.2, // virtual site
+	"mil08": 0.2, // virtual site
+	"oma01": 0.2, // virtual site
+	"ord07": 0.2, // virtual site
+	"par08": 0.2, // virtual site
+	"pdx01": 0.2, // virtual site
+	"scl05": 0.2, // virtual site
+	"sea09": 0.2, // virtual site
+	"sin02": 0.2, // virtual site
+	"slc01": 0.2, // virtual site
+	"syd07": 0.2, // virtual site
+	"tpe02": 0.2, // virtual site
 	"tun01": 0.5,
 	"vie01": 0.5,
-	"waw01": 0.1, // virtual site
+	"waw01": 0.2, // virtual site
 	"yqm01": 0.5,
 	"yul02": 0.2, // 0.2
-	"yul07": 0.1, // virtual site
+	"yul07": 0.2, // virtual site
 	"yvr01": 0.1, // 0.1
 	"ywg01": 0.5,
 	"yyc02": 0.5,
 	"yyz02": 0.2, // 0.2
-	"yyz07": 0.1, // virtual site
+	"yyz07": 0.2, // virtual site
 	"zrh01": 0.1, // virtual site
 }

--- a/static/configs.go
+++ b/static/configs.go
@@ -137,5 +137,5 @@ var SiteProbability = map[string]float64{
 	"yyc02": 0.5,
 	"yyz02": 0.2, // 0.2
 	"yyz07": 0.2, // virtual site
-	"zrh01": 0.1, // virtual site
+	"zrh01": 0.2, // virtual site
 }

--- a/static/configs.go
+++ b/static/configs.go
@@ -97,9 +97,8 @@ var SiteProbability = map[string]float64{
 	"gru02": 0.1,
 	"gru03": 0.1,
 	"gru04": 0.1,
-	"hel01": 0.2,  // virtual site
-	"hkg04": 0.2,  // virtual site
-	"hnd01": 0.05, // 0.05
+	"hel01": 0.2, // virtual site
+	"hkg04": 0.2, // virtual site
 	"hnd02": 0.1,
 	"hnd03": 0.1,
 	"hnd04": 0.1,


### PR DESCRIPTION
Double probabilities for virtual sites and add 10% probability for physical sites in bom, hnd, and gru.

Related to https://github.com/m-lab/ops-tracker/issues/1665.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/112)
<!-- Reviewable:end -->
