### PR TITLE
Sandbox soltesz update prg

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -17,11 +17,11 @@ steps:
   - go test ./... -race
   - go test -v ./...
 
-# Deployment of APIs in sandbox, staging, and mlab-ns.
+# Deployment of APIs in sandbox & staging.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18
   env:
   # Use cbif condition: only run these steps in one of these projects.
-  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-ns
+  - PROJECT_IN=mlab-sandbox,mlab-staging
   args:
   - cp cloudbuild/app.yaml.template app.yaml
   - >
@@ -31,6 +31,24 @@ steps:
     -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
     app.yaml
   - gcloud --project $PROJECT_ID app deploy --promote app.yaml
+  # After deploying the new service, deploy the openapi spec.
+  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' openapi.yaml
+  - gcloud endpoints services deploy openapi.yaml
+
+# Deployment of APIs in mlab-ns.
+- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18
+  env:
+  # Use cbif condition: only run these steps in one of these projects.
+  - PROJECT_IN=mlab-ns
+  args:
+  - cp cloudbuild/app.yaml.template app.yaml
+  - >
+    sed -i
+    -e 's/{{PROJECT}}/$PROJECT_ID/g'
+    -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
+    -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
+    app.yaml
+  - gcloud --project $PROJECT_ID app deploy --no-promote app.yaml
   # After deploying the new service, deploy the openapi spec.
   - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' openapi.yaml
   - gcloud endpoints services deploy openapi.yaml

--- a/static/configs.go
+++ b/static/configs.go
@@ -92,7 +92,7 @@ var SiteProbability = map[string]float64{
 	"cmh01": 0.2, // virtual site
 	"del03": 0.2, // virtual site
 	"dfw09": 0.2, // virtual site
-	"fra07": 0.2, // virtual site
+	"fra07": 1.0, // virtual site
 	"gru01": 0.1,
 	"gru02": 0.1,
 	"gru03": 0.1,
@@ -117,6 +117,14 @@ var SiteProbability = map[string]float64{
 	"mil08": 0.2, // virtual site
 	"oma01": 0.2, // virtual site
 	"ord07": 0.2, // virtual site
+
+	// TRIAL(github.com/m-lab/ops-tracker/issues/1720) for PRG metro.
+	"prg02": 0.3,
+	"prg03": 0.3,
+	"prg04": 0.3,
+	"prg05": 0.3,
+	"prg06": 0.3,
+
 	"par08": 0.2, // virtual site
 	"pdx01": 0.2, // virtual site
 	"scl05": 0.2, // virtual site
@@ -127,7 +135,7 @@ var SiteProbability = map[string]float64{
 	"tpe02": 0.2, // virtual site
 	"tun01": 0.5,
 	"vie01": 0.5,
-	"waw01": 0.2, // virtual site
+	"waw01": 1.0, // virtual site
 	"yqm01": 0.5,
 	"yul02": 0.2, // 0.2
 	"yul07": 0.2, // virtual site


### PR DESCRIPTION
This change adjusts the site probabilities of PRG and regional cloud sites to direct more traffic to regional locations outside of PRG.

This change additionally restores the `--no-promote` flag for production deployments due to https://github.com/m-lab/locate/issues/114

Part of:
* https://github.com/m-lab/ops-tracker/issues/1720