### PR TITLE
Remove cap for number of reconnections per hour

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -6,16 +6,16 @@ options:
   - WORKSPACE_LINK=/go/src/github.com/m-lab/locate
 
 steps:
-# Run unit tests for environment.
-- name: gcr.io/$PROJECT_ID/golang-cbif:1.18
-  env:
-  - GONOPROXY=github.com/m-lab/go/*
-  args:
-  - go version
-  - go get -v -t ./...
-  - go vet ./...
-  - go test ./... -race
-  - go test -v ./...
+# # Run unit tests for environment.
+# - name: gcr.io/$PROJECT_ID/golang-cbif:1.18
+#   env:
+#   - GONOPROXY=github.com/m-lab/go/*
+#   args:
+#   - go version
+#   - go get -v -t ./...
+#   - go vet ./...
+#   - go test ./... -race
+#   - go test -v ./...
 
 # Deployment of APIs in sandbox & staging.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -6,16 +6,16 @@ options:
   - WORKSPACE_LINK=/go/src/github.com/m-lab/locate
 
 steps:
-# # Run unit tests for environment.
-# - name: gcr.io/$PROJECT_ID/golang-cbif:1.18
-#   env:
-#   - GONOPROXY=github.com/m-lab/go/*
-#   args:
-#   - go version
-#   - go get -v -t ./...
-#   - go vet ./...
-#   - go test ./... -race
-#   - go test -v ./...
+# Run unit tests for environment.
+- name: gcr.io/$PROJECT_ID/golang-cbif:1.18
+  env:
+  - GONOPROXY=github.com/m-lab/go/*
+  args:
+  - go version
+  - go get -v -t ./...
+  - go vet ./...
+  - go test ./... -race
+  - go test -v ./...
 
 # Deployment of APIs in sandbox & staging.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -101,8 +101,7 @@ func (c *Conn) Dial(address string, header http.Header, dialMsg interface{}) err
 // The write will fail under the following conditions:
 //  1. The client has not called Dial (ErrNotDialed).
 //  2. The connection is disconnected and it was not able to
-//     reconnect (ErrTooManyReconnects or an internal connection
-//     error).
+//     reconnect.
 //  3. The write call in the websocket package failed
 //     (gorilla/websocket error).
 func (c *Conn) WriteMessage(messageType int, data interface{}) error {

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -17,9 +17,6 @@ import (
 )
 
 var (
-	// ErrTooManyReconnects is returned when the number of reconnections
-	// has reached MaxReconnectionsTotal within MaxElapsedTime.
-	ErrTooManyReconnects = errors.New("websocket cannot reconnect right now (too many attemps)")
 	// ErrNotDialed is returned when WriteMessage is called, but
 	// the websocket has not been created yet (call Dial).
 	ErrNotDailed = errors.New("websocket not created yet, please call Dial()")
@@ -48,36 +45,25 @@ type Conn struct {
 	// MaxElapsedTime is the amount of time after which the ExponentialBackOff
 	// returns Stop. It never stops if MaxElapsedTime == 0.
 	MaxElapsedTime time.Duration
-	// MaxReconnectionsTotal is the maximum number of reconnections that can
-	// happen within MaxReconnectionsTime.
-	MaxReconnectionsTotal int
-	// MaxReconnectionsTime is the time period during which the number of
-	// reconnections must be less than MaxReconnectionsTotal to allow a
-	// reconnection atttempt.
-	MaxReconnectionsTime time.Duration
-	dialer               websocket.Dialer
-	ws                   *websocket.Conn
-	url                  url.URL
-	header               http.Header
-	dialMessage          interface{}
-	ticker               time.Ticker
-	mu                   sync.Mutex
-	reconnections        int
-	isDialed             bool
-	isConnected          bool
-	stop                 chan bool
+	dialer         websocket.Dialer
+	ws             *websocket.Conn
+	url            url.URL
+	header         http.Header
+	dialMessage    interface{}
+	ticker         time.Ticker
+	mu             sync.Mutex
+	isDialed       bool
+	isConnected    bool
 }
 
 // NewConn creates a new Conn with default values.
 func NewConn() *Conn {
 	c := &Conn{
-		InitialInterval:       static.BackoffInitialInterval,
-		RandomizationFactor:   static.BackoffRandomizationFactor,
-		Multiplier:            static.BackoffMultiplier,
-		MaxInterval:           static.BackoffMaxInterval,
-		MaxElapsedTime:        static.BackoffMaxElapsedTime,
-		MaxReconnectionsTotal: static.MaxReconnectionsTotal,
-		MaxReconnectionsTime:  static.MaxReconnectionsTime,
+		InitialInterval:     static.BackoffInitialInterval,
+		RandomizationFactor: static.BackoffRandomizationFactor,
+		Multiplier:          static.BackoffMultiplier,
+		MaxInterval:         static.BackoffMaxInterval,
+		MaxElapsedTime:      static.BackoffMaxElapsedTime,
 	}
 	return c
 }
@@ -101,23 +87,9 @@ func (c *Conn) Dial(address string, header http.Header, dialMsg interface{}) err
 	}
 	c.url = *u
 	c.dialMessage = dialMsg
-	c.stop = make(chan bool)
 	c.header = header
 	c.dialer = websocket.Dialer{}
 	c.isDialed = true
-	c.ticker = *time.NewTicker(c.MaxReconnectionsTime)
-	go func(c *Conn) {
-		for {
-			select {
-			case <-c.stop:
-				c.ticker.Stop()
-				return
-			case <-c.ticker.C:
-				c.resetReconnections()
-			}
-		}
-	}(c)
-
 	return c.connect()
 }
 
@@ -160,39 +132,22 @@ func (c *Conn) IsConnected() bool {
 	return c.isConnected
 }
 
-// CanConnect checks whether it is possible to reconnect
-// given the recent number of attempts.
-func (c *Conn) CanConnect() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.reconnections < c.MaxReconnectionsTotal
-}
-
 // Close closes the network connection and cleans up private
 // resources after the connection is done.
 func (c *Conn) Close() error {
 	if c.isDialed {
 		c.isDialed = false
-		c.stop <- true
 	}
 	return c.close()
 }
 
-// resetReconnections sets the number of disconnects followed
-// by reconnects.
-func (c *Conn) resetReconnections() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.reconnections = 0
-}
-
-// closeAndReconnect calls close and reconnect.
+// closeAndReconnect calls close and reconnects.
 func (c *Conn) closeAndReconnect() error {
 	err := c.close()
 	if err != nil {
 		return err
 	}
-	return c.reconnect()
+	return c.connect()
 }
 
 // close closes the underlying network connection without
@@ -205,18 +160,6 @@ func (c *Conn) close() error {
 		}
 	}
 	return nil
-}
-
-// reconnect updates the number of reconnections and
-// re-establishes the connection.
-func (c *Conn) reconnect() error {
-	if !c.CanConnect() {
-		return ErrTooManyReconnects
-	}
-	c.mu.Lock()
-	c.reconnections++
-	c.mu.Unlock()
-	return c.connect()
 }
 
 // connect creates a new client connection and sends the

--- a/static/configs.go
+++ b/static/configs.go
@@ -20,8 +20,6 @@ const (
 	BackoffMultiplier          = 2
 	BackoffMaxInterval         = time.Hour
 	BackoffMaxElapsedTime      = 0
-	MaxReconnectionsTotal      = 10
-	MaxReconnectionsTime       = time.Hour
 	HeartbeatPeriod            = 10 * time.Second
 	MemorystoreExportPeriod    = 10 * time.Second
 	PrometheusCheckPeriod      = time.Minute

--- a/static/configs.go
+++ b/static/configs.go
@@ -18,7 +18,7 @@ const (
 	BackoffInitialInterval     = time.Second
 	BackoffRandomizationFactor = 0.5
 	BackoffMultiplier          = 2
-	BackoffMaxInterval         = time.Hour
+	BackoffMaxInterval         = 5 * time.Minute
 	BackoffMaxElapsedTime      = 0
 	HeartbeatPeriod            = 10 * time.Second
 	MemorystoreExportPeriod    = 10 * time.Second


### PR DESCRIPTION
This PR removes the 10 reconnections per hour cap. It also reduces the reconnection backoff maximum interval to 5 minutes.

When a new version is promoted/created, the heartbeat instances briefly disconnect from the old version and reconnect to the new one. This can sometimes take a surprisingly long time if an instance hits the maximum number of reconnections attempts (10), at which point it has to wait a whole hour to reconnect, or if the retry backoff increases significantly.

This scenario can be reproduced in sandbox. That said, the problem is much less likely to happen since the introduction of the App Engine [custom request handlers](https://github.com/m-lab/locate/pull/118). 

![Screenshot 2023-02-27 12 09 40 PM](https://user-images.githubusercontent.com/21001496/221632424-32ce5ff6-c339-43ec-bae8-6969e03e1e4e.png)

This is part of the remediation for https://github.com/m-lab/locate/issues/114.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/120)
<!-- Reviewable:end -->
