### PR TITLE
Add histogram to track ranked distance of selected servers

### DIFF
--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"net/url"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/m-lab/go/host"
 	"github.com/m-lab/go/mathx"
 	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/locate/metrics"
 	"github.com/m-lab/locate/static"
 )
 
@@ -190,6 +192,7 @@ func pickTargets(service string, sites []site) ([]v2.Target, []url.URL) {
 
 	for i := 0; i < numTargets; i++ {
 		index := rand.GetExpDistributedInt(1) % len(sites)
+		metrics.ServerDistanceRanking.WithLabelValues(strconv.Itoa(i)).Observe(float64(index))
 		s := sites[index]
 		// TODO(cristinaleon): Once health values range between 0 and 1,
 		// pick based on health. For now, pick at random.

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -180,9 +180,8 @@ func sortSites(sites []site) {
 	sort.Slice(sites, func(i, j int) bool {
 		return sites[i].distance < sites[j].distance
 	})
-
-	for i, site := range sites {
-		site.rank = i
+	for i := range sites {
+		sites[i].rank = i
 	}
 }
 

--- a/heartbeat/location_test.go
+++ b/heartbeat/location_test.go
@@ -350,6 +350,10 @@ func TestFilterSites(t *testing.T) {
 		"physical": physicalInstance,
 		"wehe":     weheInstance,
 	}
+	vSite0 := site(virtualSite)
+	vSite0.rank = 0
+	pSite1 := site(physicalSite)
+	pSite1.rank = 1
 
 	tests := []struct {
 		name     string
@@ -367,7 +371,7 @@ func TestFilterSites(t *testing.T) {
 			country:  "US",
 			lat:      43.1988,
 			lon:      -75.3242,
-			expected: []site{virtualSite, physicalSite},
+			expected: []site{vSite0, pSite1},
 		},
 		{
 			name:     "NDT7-physical",
@@ -614,14 +618,15 @@ func TestSortSites(t *testing.T) {
 		{
 			name:     "one",
 			sites:    []site{{distance: 10}},
-			expected: []site{{distance: 10}},
+			expected: []site{{distance: 10, rank: 0}},
 		},
 		{
 			name: "many",
 			sites: []site{{distance: 3838.61}, {distance: 3710.7679340078703}, {distance: -895420.92},
 				{distance: 296.0436}, {distance: math.MaxFloat64}, {distance: 3838.61}},
-			expected: []site{{distance: -895420.92}, {distance: 296.0436}, {distance: 3710.7679340078703},
-				{distance: 3838.61}, {distance: 3838.61}, {distance: math.MaxFloat64}},
+			expected: []site{{distance: -895420.92, rank: 0}, {distance: 296.0436, rank: 1},
+				{distance: 3710.7679340078703, rank: 2}, {distance: 3838.61, rank: 3},
+				{distance: 3838.61, rank: 4}, {distance: math.MaxFloat64, rank: 5}},
 		},
 	}
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -82,8 +82,9 @@ var (
 	// metrics.ServerDistanceRanking.WithLabelValues(0).Observe(1)
 	ServerDistanceRanking = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "locate_server_distance_ranking",
-			Help: "A histogram of server selection rankings with respect to distance from the client.",
+			Name:    "locate_server_distance_ranking",
+			Help:    "A histogram of server selection rankings with respect to distance from the client.",
+			Buckets: prometheus.LinearBuckets(0, 1000, 1),
 		},
 		[]string{"index"},
 	)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -74,6 +74,20 @@ var (
 		[]string{"code"},
 	)
 
+	// ServerDistanceRanking is a histogram that tracks the ranked distance of the returned servers
+	// with respect to the client.
+	// Numbering is zero-based.
+	//
+	// Example usage (the 2nd closest server to the client is returned as the 1st server in the list):
+	// metrics.ServerDistanceRanking.WithLabelValues(0).Observe(1)
+	ServerDistanceRanking = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "locate_server_distance_ranking",
+			Help: "A histogram of server selection rankings with respect to distance from the client.",
+		},
+		[]string{"return-index"},
+	)
+
 	// ConnectionRequestsTotal counts the number of (re)connection requests the Heartbeat Service
 	// makes to the Locate Service.
 	ConnectionRequestsTotal = promauto.NewCounterVec(

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -85,7 +85,7 @@ var (
 			Name: "locate_server_distance_ranking",
 			Help: "A histogram of server selection rankings with respect to distance from the client.",
 		},
-		[]string{"return-index"},
+		[]string{"index"},
 	)
 
 	// ConnectionRequestsTotal counts the number of (re)connection requests the Heartbeat Service

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -84,7 +84,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "locate_server_distance_ranking",
 			Help:    "A histogram of server selection rankings with respect to distance from the client.",
-			Buckets: prometheus.LinearBuckets(0, 1000, 1),
+			Buckets: prometheus.LinearBuckets(0, 1, 1000),
 		},
 		[]string{"index"},
 	)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -13,6 +13,7 @@ func TestLintMetrics(t *testing.T) {
 	LocateHealthStatus.WithLabelValues("experiment").Set(0)
 	ImportMemorystoreTotal.WithLabelValues("status")
 	PrometheusHealthCollectionDuration.WithLabelValues("code")
+	ServerDistanceRanking.WithLabelValues("return-index")
 	ConnectionRequestsTotal.WithLabelValues("status")
 	PortChecksTotal.WithLabelValues("status")
 	KubernetesRequestsTotal.WithLabelValues("status")

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -13,7 +13,7 @@ func TestLintMetrics(t *testing.T) {
 	LocateHealthStatus.WithLabelValues("experiment").Set(0)
 	ImportMemorystoreTotal.WithLabelValues("status")
 	PrometheusHealthCollectionDuration.WithLabelValues("code")
-	ServerDistanceRanking.WithLabelValues("return-index")
+	ServerDistanceRanking.WithLabelValues("index")
 	ConnectionRequestsTotal.WithLabelValues("status")
 	PortChecksTotal.WithLabelValues("status")
 	KubernetesRequestsTotal.WithLabelValues("status")


### PR DESCRIPTION
This PR adds a new metric to track the ranked distance of the selected servers with respect to the client (e.g., 1st closest, 2nd closest).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/121)
<!-- Reviewable:end -->
