### PR TITLE
Enable the --promote flag in mlab-ns

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -17,11 +17,11 @@ steps:
   - go test ./... -race
   - go test -v ./...
 
-# Deployment of APIs in sandbox & staging.
+# Deployment of APIs in sandbox, staging, and mlab-ns.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18
   env:
   # Use cbif condition: only run these steps in one of these projects.
-  - PROJECT_IN=mlab-sandbox,mlab-staging
+  - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-ns
   args:
   - cp cloudbuild/app.yaml.template app.yaml
   - >
@@ -31,24 +31,6 @@ steps:
     -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
     app.yaml
   - gcloud --project $PROJECT_ID app deploy --promote app.yaml
-  # After deploying the new service, deploy the openapi spec.
-  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' openapi.yaml
-  - gcloud endpoints services deploy openapi.yaml
-
-# Deployment of APIs in mlab-ns.
-- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.18
-  env:
-  # Use cbif condition: only run these steps in one of these projects.
-  - PROJECT_IN=mlab-ns
-  args:
-  - cp cloudbuild/app.yaml.template app.yaml
-  - >
-    sed -i
-    -e 's/{{PROJECT}}/$PROJECT_ID/g'
-    -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
-    -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
-    app.yaml
-  - gcloud --project $PROJECT_ID app deploy --no-promote app.yaml
   # After deploying the new service, deploy the openapi spec.
   - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' openapi.yaml
   - gcloud endpoints services deploy openapi.yaml


### PR DESCRIPTION
This PR re-enables the `--promote` flag in mlab-ns now that we've implemented https://github.com/m-lab/locate/pull/119 and https://github.com/m-lab/locate/pull/118 to fix and have more visibility into promotion outages such as https://github.com/m-lab/locate/issues/114.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/122)
<!-- Reviewable:end -->
