### PR TITLE
Change server ranking metric max to 20

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -84,7 +84,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "locate_server_distance_ranking",
 			Help:    "A histogram of server selection rankings with respect to distance from the client.",
-			Buckets: prometheus.LinearBuckets(0, 1, 1000),
+			Buckets: prometheus.LinearBuckets(0, 1, 20),
 		},
 		[]string{"index"},
 	)


### PR DESCRIPTION
This PR changes the max for the `locate_server_distance_ranking` to 20. Even though we have hundreds of servers, practically, the ranked distance of the selected servers will almost always be less than 20.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/124)
<!-- Reviewable:end -->
