### PR TITLE
Add metro ranking

### DIFF
--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -83,7 +83,7 @@ func (l *Locator) Nearest(service string, lat, lon float64, opts *NearestOptions
 	sortSites(sites)
 
 	// Rank.
-	rankSites(sites)
+	rank(sites)
 
 	// Pick.
 	result := pickTargets(service, sites)
@@ -194,8 +194,8 @@ func sortSites(sites []site) {
 	})
 }
 
-// rankSites ranks the sites and metros.
-func rankSites(sites []site) {
+// rank ranks sites and metros.
+func rank(sites []site) {
 	metroRank := 0
 	metros := make(map[string]int)
 	for i, site := range sites {

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -43,6 +43,7 @@ type machine struct {
 type site struct {
 	distance     float64
 	rank         int
+	metroRank    int
 	registration v2.Registration
 	machines     []machine
 }
@@ -180,8 +181,19 @@ func sortSites(sites []site) {
 	sort.Slice(sites, func(i, j int) bool {
 		return sites[i].distance < sites[j].distance
 	})
-	for i := range sites {
+
+	metroRank := 0
+	metros := make(map[string]int)
+	for i, site := range sites {
 		sites[i].rank = i
+
+		metro := site.registration.Metro
+		_, ok := metros[metro]
+		if !ok {
+			metros[metro] = metroRank
+			metroRank++
+		}
+		sites[i].metroRank = metros[metro]
 	}
 }
 

--- a/heartbeat/location_test.go
+++ b/heartbeat/location_test.go
@@ -683,7 +683,7 @@ func TestRankSites(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rankSites(tt.sites)
+			rank(tt.sites)
 
 			if !reflect.DeepEqual(tt.sites, tt.expected) {
 				t.Errorf("rankSites() got: %+v, want: %+v", tt.sites, tt.expected)

--- a/locatetest/locatetest.go
+++ b/locatetest/locatetest.go
@@ -55,15 +55,18 @@ type LocatorV2 struct {
 }
 
 // Nearest returns the pre-configured LocatorV2 Servers or Err.
-func (l *LocatorV2) Nearest(service string, lat, lon float64, opts *heartbeat.NearestOptions) ([]v2.Target, []url.URL, error) {
+func (l *LocatorV2) Nearest(service string, lat, lon float64, opts *heartbeat.NearestOptions) (*heartbeat.TargetInfo, error) {
 	if l.Err != nil {
-		return nil, nil, l.Err
+		return nil, l.Err
 	}
 	t := make([]v2.Target, len(l.Servers))
 	for i := range l.Servers {
 		t[i].Machine = l.Servers[i]
 	}
-	return t, []url.URL{}, nil
+	return &heartbeat.TargetInfo{
+		Targets: t,
+		URLs:    []url.URL{},
+	}, nil
 }
 
 // NewLocateServer creates an httptest.Server that can respond to Locate API v2

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -89,6 +89,21 @@ var (
 		[]string{"index"},
 	)
 
+	// MetroDistanceRanking is a histogram that tracks the ranked distance of the returned metros
+	// with respect to the client.
+	// Numbering is zero-based.
+	//
+	// Example usage (the 1st server in the list is in the 2nd metro closest to the client):
+	// metrics.MetroDistanceRanking.WithLabelValues(0).Observe(1)
+	MetroDistanceRanking = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "locate_metro_distance_ranking",
+			Help:    "A histogram of metro selection rankings with respect to distance from the client.",
+			Buckets: prometheus.LinearBuckets(0, 1, 20),
+		},
+		[]string{"index"},
+	)
+
 	// ConnectionRequestsTotal counts the number of (re)connection requests the Heartbeat Service
 	// makes to the Locate Service.
 	ConnectionRequestsTotal = promauto.NewCounterVec(

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -14,6 +14,7 @@ func TestLintMetrics(t *testing.T) {
 	ImportMemorystoreTotal.WithLabelValues("status")
 	PrometheusHealthCollectionDuration.WithLabelValues("code")
 	ServerDistanceRanking.WithLabelValues("index")
+	MetroDistanceRanking.WithLabelValues("index")
 	ConnectionRequestsTotal.WithLabelValues("status")
 	PortChecksTotal.WithLabelValues("status")
 	KubernetesRequestsTotal.WithLabelValues("status")


### PR DESCRIPTION
This PR adds a new `metro_rank` parameter to the output URLs. Specifically, it adds a `Ranks` field to the output of the `LocatorV2.Nearest()` function containing a mapping of machine hostnames to their metro ranking (based on distance from the client).

It also adds the metro ranking to a `locate_metro_distance_ranking` histogram metric.

The URL parameter can be seen [here](https://locate-dot-mlab-sandbox.appspot.com/v2/nearest/ndt/ndt7) and the metric [here](https://prometheus.mlab-sandbox.measurementlab.net/graph?g0.expr=locate_metro_distance_ranking_bucket&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=12h).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/126)
<!-- Reviewable:end -->
