### PR TITLE
Removes hnd02 and hnd04 from SiteProbability map

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -97,10 +97,8 @@ var SiteProbability = map[string]float64{
 	"gru04": 0.1,
 	"hel01": 0.2, // virtual site
 	"hkg04": 0.2, // virtual site
-	"hnd02": 0.1,
 	"hnd03": 0.1,
 	"hnd04": 0.1,
-	"hnd05": 0.1,
 	"iad07": 0.2, // virtual site
 	"icn01": 0.2, // virtual site
 	"kix01": 0.2, // virtual site


### PR DESCRIPTION
We are going to keep these two physical sites. Send them full traffic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/128)
<!-- Reviewable:end -->
