### PR TITLE
Add minimum number of instances

### DIFF
--- a/cloudbuild/app.yaml.template
+++ b/cloudbuild/app.yaml.template
@@ -17,6 +17,7 @@ network:
     - 9090/tcp
 
 automatic_scaling:
+  min_num_instances: 15
   max_num_instances: 40
   cool_down_period_sec: 300
 


### PR DESCRIPTION
This PR sets the minimum number of App Engine instances to 15 (the default is 2).

The number 15 was picked because the minimum number of instances that App Engine scales down to in mlab-ns seeems to be ~13, so 15 would be a safe, round minimum which would at most only result in ~2 extra instances.
![Screenshot 2023-03-27 6 44 32 PM](https://user-images.githubusercontent.com/21001496/228083661-6655e318-bf73-4846-b1c9-32f1beec4af4.png)


When no minimum is set, the instances gradually come up as a new version is deployed. This causes the Load Balancer to throw 502 errors with the reason `failed_to_pick_backend`. 

These errors can be seen on App Engine's dashboard right after a new version is deployed.

- Last deployment to mlab-ns:
![Screenshot 2023-03-27 6 33 08 PM](https://user-images.githubusercontent.com/21001496/228081812-804970bf-6b68-4298-ae1f-7e598299f5f8.png)

- Issue reproduced in staging:
![Screenshot 2023-03-27 6 41 53 PM](https://user-images.githubusercontent.com/21001496/228083123-423f3948-5871-4a07-81ec-6fd106f6be6a.png)


They can also be seen in the logs ([mlab-ns](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22http_load_balancer%22%0AhttpRequest.status%3D502;timeRange=2023-03-07T17:00:30.985Z%2F2023-03-07T17:00:30.985Z--PT1H;cursorTimestamp=2023-03-07T17:01:21.929609Z?project=mlab-ns), [staging](https://pantheon.corp.google.com/logs/query;query=--resource.type%3D%22gae_app%22%0A--resource.labels.module_id%3D%22locate%22%0AhttpRequest.status%3D502%0A--%22v2%2Fnearest%22%0A--log_name%3D%22projects%2Fmlab-staging%2Flogs%2Fappengine.googleapis.com%252Fnginx.request%22%0Aresource.type%3D%22http_load_balancer%22%0A--jsonPayload.statusDetails!%3D%22failed_to_pick_backend%22;timeRange=2023-03-27T20:14:43.117Z%2F2023-03-27T20:14:43.117Z--PT1H;cursorTimestamp=2023-03-27T20:14:52.638764Z?serviceId=locate&project=mlab-staging)).


When a minimum is set, the new version does not start serving until the minimum number of instances is up, and no 5XX  errors are observed ([log](https://pantheon.corp.google.com/logs/query;query=httpRequest.status%3D502%0Aresource.type%3D%22http_load_balancer%22%0A;timeRange=2023-03-27T22:14:43.117Z%2F2023-03-27T22:14:43.117Z--PT1H;cursorTimestamp=2023-03-27T22:17:11.194Z?serviceId=locate&project=mlab-staging)): 
![Screenshot 2023-03-27 6 37 39 PM](https://user-images.githubusercontent.com/21001496/228082470-777a25dc-6fa8-448c-8f84-698bbcccdeb1.png)




<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/129)
<!-- Reviewable:end -->
