### PR TITLE
Add lga sites for larger spray experiment

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -105,6 +105,15 @@ var SiteProbability = map[string]float64{
 	"las01": 0.3, // virtual site
 	"lax07": 0.3, // virtual site
 	"lga1t": 0.5,
+
+	// LGA spray experiment.
+	// TODO(soltesz): reset after 1 week on 2023-05-03.
+	"lga04": 0.5,
+	"lga05": 0.5,
+	"lga06": 0.5,
+	"lga08": 0.5,
+	"lga09": 0.5,
+
 	"lhr09": 0.3, // virtual site
 	"lis01": 0.5,
 	"lju01": 0.5,


### PR DESCRIPTION
This change reduces the probability of all LGA sites to 0.5. This temporary spray experiment is in service of sending more clients that would ordinarily be directed to LGA to other nearby metro areas and Cloud sites, specifically: IAD, YUL, YYZ, and possibly CMH or CHS).

This configuration update is necessary to limit the impact to only LGA clients and to use an already available mechanism in the Locate service.

This setting should be reverted in 1 week.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/132)
<!-- Reviewable:end -->
