### PR TITLE
Revert LGA spread experiment

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -106,14 +106,6 @@ var SiteProbability = map[string]float64{
 	"lax07": 0.3, // virtual site
 	"lga1t": 0.5,
 
-	// LGA spray experiment.
-	// TODO(soltesz): reset after 1 week on 2023-05-03.
-	"lga04": 0.5,
-	"lga05": 0.5,
-	"lga06": 0.5,
-	"lga08": 0.5,
-	"lga09": 0.5,
-
 	"lhr09": 0.3, // virtual site
 	"lis01": 0.5,
 	"lju01": 0.5,


### PR DESCRIPTION
This change reverts the lower probability for LGA sites and concludes the spray experiment between LGA & IAD.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/133)
<!-- Reviewable:end -->
