### PR TITLE
Reduce ATL metro probability to .5 (for one week)

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -82,6 +82,14 @@ var LegacyServices = map[string]string{
 // TODO(github.com/m-lab/locate/issues/92): Make this dynamic.
 var SiteProbability = map[string]float64{
 	"ams10": 0.3, // virtual site
+
+	// TODO(soltesz): revert ATL/CHS trial after 2023-05-15.
+	"atl02": 0.5,
+	"atl03": 0.5,
+	"atl04": 0.5,
+	"atl07": 0.5,
+	"atl08": 0.5,
+
 	"bom01": 0.1,
 	"bom02": 0.1,
 	"bru06": 0.3, // virtual site


### PR DESCRIPTION
Following the LGA trial (https://github.com/m-lab/locate/pull/132 https://github.com/m-lab/locate/pull/133) this change updates sites at the ATL metro to 0.5 to distribute more clients to CHS in Google Cloud. This is a limited trial that will run for only one week.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/134)
<!-- Reviewable:end -->
