### PR TITLE
Remove ATL adjustments

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -83,13 +83,6 @@ var LegacyServices = map[string]string{
 var SiteProbability = map[string]float64{
 	"ams10": 0.3, // virtual site
 
-	// TODO(soltesz): revert ATL/CHS trial after 2023-05-15.
-	"atl02": 0.5,
-	"atl03": 0.5,
-	"atl04": 0.5,
-	"atl07": 0.5,
-	"atl08": 0.5,
-
 	"bom01": 0.1,
 	"bom02": 0.1,
 	"bru06": 0.3, // virtual site


### PR DESCRIPTION
This change reverts the temporary reduced site probabilities around ATL https://github.com/m-lab/locate/pull/134 - after collecting data for one week, we should have sufficient data for a similar spray analysis between ATL and CHS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/135)
<!-- Reviewable:end -->
