### PR TITLE
Add static configs for all remote GCP regions

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -81,60 +81,132 @@ var LegacyServices = map[string]string{
 // the current number of requests. The default value is 1.0.
 // TODO(github.com/m-lab/locate/issues/92): Make this dynamic.
 var SiteProbability = map[string]float64{
-	"ams10": 0.3, // virtual site
-
-	"bom01": 0.1,
-	"bom02": 0.1,
-	"bru06": 0.3, // virtual site
-	"cgk01": 0.3, // virtual site
+	// TRIALS(soltesz): Until 2023-05-24
+	// ATL MIA -> South Carolina chs
 	"chs01": 1.0, // virtual site
-	"cmh01": 1.0, // virtual site
-	"del03": 0.3, // virtual site
-	"dfw09": 0.3, // virtual site
-	"fra07": 1.0, // virtual site
-	"gru01": 0.1,
-	"gru02": 0.1,
-	"gru03": 0.1,
-	"gru04": 0.1,
-	"hel01": 0.3, // virtual site
-	"hkg04": 0.3, // virtual site
-	"hnd03": 0.1,
-	"hnd04": 0.1,
-	"iad07": 1.0, // virtual site
-	"icn01": 0.3, // virtual site
-	"kix01": 0.3, // virtual site
-	"las01": 0.3, // virtual site
-	"lax07": 0.3, // virtual site
-	"lga1t": 0.5,
+	"atl02": 0.3,
+	"atl03": 0.3,
+	"atl04": 0.3,
+	"atl07": 0.3,
+	"atl08": 0.3,
+	"mia02": 0.3,
+	"mia03": 0.3,
+	"mia04": 0.3,
+	"mia05": 0.3,
+	"mia06": 0.3,
 
-	"lhr09": 0.3, // virtual site
-	"lis01": 0.5,
-	"lju01": 0.5,
-	"mad07": 0.3, // virtual site
-	"mel01": 0.3, // virtual site
-	"mil08": 0.3, // virtual site
-	"oma01": 0.3, // virtual site
-	"ord07": 0.3, // virtual site
+	// NUQ LAX -> Las Vegas las & Los Angeles lax
+	"las01": 1.0, // virtual site
+	"lax07": 1.0, // virtual site
+	"nuq02": 0.3,
+	"nuq03": 0.3,
+	"nuq04": 0.3,
+	"nuq06": 0.3,
+	"nuq07": 0.3,
+	"lax02": 0.3,
+	"lax03": 0.3,
+	"lax04": 0.3,
+	"lax05": 0.3,
+	"lax06": 0.3,
+
+	// ARN Sweden -> Finland hel01
+	"hel01": 1.0, // virtual site
+	"arn02": 0.3,
+	"arn03": 0.3,
+	"arn04": 0.3,
+	"arn05": 0.3,
+	"arn06": 0.3,
+	// SVG (Norway)
+	"svg01": 0.3,
+
+	// YVR & SEA -> Oregon pdx01
+	"pdx01": 1.0, // virtual site
+	"yvr02": 0.3,
+	"yvr03": 0.3,
+	"yvr04": 0.3,
+	"sea02": 0.2, // YVR must get past SEA to reach PDX.
+	"sea03": 0.2,
+	"sea04": 0.2,
+	"sea07": 0.2,
+	"sea08": 0.2,
+
+	// DEN -> Salt Lake City slc & oma
+	"oma01": 1.0, // virtual site
+	"slc01": 1.0, // virtual site
+	"den02": 0.3,
+	"den04": 0.3,
+	"den05": 0.3,
+	"den06": 0.3,
+
+	// EZE (Argentina) -> Santiago (Chile) scl
+	"scl05": 1.0, // virtual site
+	"eze01": 0.3,
+	"eze02": 0.3,
+	"eze03": 0.3,
+	"eze04": 0.3,
+
+	// MRS (France) -> Milan Italy
+	"zrh01": 1.0, // virtual site
+	"mad07": 1.0, // virtual site
+	"mil08": 1.0, // virtual site
+	"mrs01": 0.3,
+	"mrs02": 0.3,
+	"mrs03": 0.3,
+	"mrs04": 0.3,
+	"mil02": 0.2, // There are many mil sites.
+	"mil03": 0.2,
+	"mil04": 0.2,
+	"mil05": 0.2,
+	"mil06": 0.2,
+	"mil07": 0.2,
+	"trn02": 0.2, // Singleton: Prefer mil08
+	"bcn01": 0.2, // Singleton: Prefer nearby metros.
 
 	// TRIAL(github.com/m-lab/ops-tracker/issues/1720) for PRG metro.
+	"waw01": 1.0, // virtual site
+	"par08": 1.0, // virtual site
 	"prg02": 0.3,
 	"prg03": 0.3,
 	"prg04": 0.3,
 	"prg05": 0.3,
 	"prg06": 0.3,
 
-	"par08": 0.3, // virtual site
-	"pdx01": 0.3, // virtual site
-	"scl05": 0.3, // virtual site
-	"sea09": 0.3, // virtual site
+	// GIG (Rio) -> GRU (Sao Paulo)
+	"gru01": 0.2,
+	"gru02": 0.2,
+	"gru03": 0.2,
+	"gru04": 0.2,
+	"gru05": 1.0, // virtual site
+	"gig01": 0.2,
+	"gig02": 0.2,
+	"gig03": 0.2,
+	"gig04": 0.2,
+
+	"ams10": 0.3, // virtual site
+	"bom01": 0.1, // 1g site
+	"bru06": 0.3, // virtual site
+	"cgk01": 0.3, // virtual site
+	"cmh01": 1.0, // virtual site
+	"del03": 0.3, // virtual site
+	"dfw09": 0.3, // virtual site
+	"fra07": 1.0, // virtual site
+	"hkg04": 0.3, // virtual site
+	"iad07": 1.0, // virtual site
+	"icn01": 0.3, // virtual site
+	"kix01": 0.3, // virtual site
+	"lax08": 1.0, // virtual site
+	"lga1t": 0.5,
+
+	"lhr09": 0.3, // virtual site
+	"lis01": 0.5,
+	"lju01": 0.5,
+	"mel01": 0.3, // virtual site
+	"ord07": 0.3, // virtual site
+
 	"sin02": 0.3, // virtual site
-	"slc01": 0.3, // virtual site
 	"syd07": 0.3, // virtual site
 	"tpe02": 0.3, // virtual site
 	"tun01": 0.5,
-	"vie01": 0.5,
-	"waw01": 1.0, // virtual site
 	"yul07": 1.0, // virtual site
 	"yyz07": 1.0, // virtual site
-	"zrh01": 0.3, // virtual site
 }


### PR DESCRIPTION
This change updates site probabilities to bias towards GCP regions that are "remote but maybe close enough". This change follows trial with LGA/IAD and ATL/CHS and applies similar configurations for all remaining regions summarized below:

Site | GCP | Traffic Migration | 
-- | -- | -- |
ATL | South Carolina | ATL->South Carolina | 
NUQ | Los Angeles | NUQ->Los Angeles | 
ARN | Finland | ARN->Finland | 
YVR | Oregon | YVR->Oregon |
MIA | South Carolina | MIA->South Carolina |
DEN | Salt Lake City | DEN->Salt Lake City |
EZE | Santiago | EZE->Santiago |
MRS | Turin | MRS->Turin |
PRG | Frankfurt | PRG->Frankfurt |
GIG  | Sao Paulo | GIG -> Sao Paulo |

Note:
* we are enabling the ATL probability changes to collect more data.
* site probabilities are lower than previous changes (0.5 for lga, 0.4 for atl) to encourage more distribution than previously observed.
* this configuration should only run for a week, pending confirmation that there are sufficient tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/136)
<!-- Reviewable:end -->
