### PR TITLE
Increases virtual site dfw09 probability to 1.0

### DIFF
--- a/static/configs.go
+++ b/static/configs.go
@@ -87,7 +87,7 @@ var SiteProbability = map[string]float64{
 	"chs01": 1.0, // virtual site
 	"cmh01": 1.0, // virtual site
 	"del03": 0.3, // virtual site
-	"dfw09": 0.3, // virtual site
+	"dfw09": 1.0, // virtual site
 	"fra07": 1.0, // virtual site
 	"gru05": 1.0, // virtual site
 	"hel01": 1.0, // virtual site


### PR DESCRIPTION
Since physical site dfw05 was retired, the remaining dfw sites have become overloaded, especially by periodic spike traffic. Giving the virtual dfw site full probability will hopefully help alleviate some of the traffic issues to the remaining physical sites. We will also add additional VMs to dfw09.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/140)
<!-- Reviewable:end -->
