### PR TITLE
Add a SIGTERM handler for the heartbeat

### DIFF
--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -116,11 +116,13 @@ func getHealth(hc *health.Checker) float64 {
 func catchSigterm(ws *connection.Conn) {
 	// Register channel to receive SIGTERM events.
 	c := make(chan os.Signal, 1)
+	defer close(c)
 	signal.Notify(c, syscall.SIGTERM)
 
 	for {
 		// Wait until we receive a SIGTERM.
 		log.Println("received signal: ", <-c)
+
 		// Notify the receiver that the health score should now be 0.
 		hbm := v2.HeartbeatMessage{
 			Health: &v2.Health{
@@ -131,5 +133,8 @@ func catchSigterm(ws *connection.Conn) {
 		if err != nil {
 			log.Printf("failed to write final health message, err: %v", err)
 		}
+
+		// Cancel the main context.
+		mainCancel()
 	}
 }

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -69,7 +69,6 @@ func main() {
 	conn := connection.NewConn()
 	err = conn.Dial(heartbeatURL, http.Header{}, hbm)
 	rtx.Must(err, "failed to establish a websocket connection with %s", heartbeatURL)
-	go catchSigterm(conn)
 
 	probe := health.NewPortProbe(s)
 	hc := &health.Checker{}
@@ -90,9 +89,21 @@ func write(ws *connection.Conn, hc *health.Checker) {
 	ticker := *time.NewTicker(heartbeatPeriod)
 	defer ticker.Stop()
 
+	// Register the channel to receive SIGTERM events.
+	sigterm := make(chan os.Signal, 1)
+	defer close(sigterm)
+	signal.Notify(sigterm, syscall.SIGTERM)
+
 	for {
 		select {
 		case <-mainCtx.Done():
+			log.Println("context cancelled")
+			sendExitMessage(ws)
+			return
+		case <-sigterm:
+			log.Println("received SIGTERM")
+			sendExitMessage(ws)
+			mainCancel()
 			return
 		case <-ticker.C:
 			score := getHealth(hc)
@@ -113,28 +124,15 @@ func getHealth(hc *health.Checker) float64 {
 	return hc.GetHealth(ctx)
 }
 
-func catchSigterm(ws *connection.Conn) {
-	// Register channel to receive SIGTERM events.
-	c := make(chan os.Signal, 1)
-	defer close(c)
-	signal.Notify(c, syscall.SIGTERM)
-
-	for {
-		// Wait until we receive a SIGTERM.
-		log.Println("received signal: ", <-c)
-
-		// Notify the receiver that the health score should now be 0.
-		hbm := v2.HeartbeatMessage{
-			Health: &v2.Health{
-				Score: 0,
-			},
-		}
-		err := ws.WriteMessage(websocket.TextMessage, hbm)
-		if err != nil {
-			log.Printf("failed to write final health message, err: %v", err)
-		}
-
-		// Cancel the main context.
-		mainCancel()
+func sendExitMessage(ws *connection.Conn) {
+	// Notify the receiver that the health score should now be 0.
+	hbm := v2.HeartbeatMessage{
+		Health: &v2.Health{
+			Score: 0,
+		},
+	}
+	err := ws.WriteMessage(websocket.TextMessage, hbm)
+	if err != nil {
+		log.Printf("failed to write final health message, err: %v", err)
 	}
 }

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -121,12 +121,12 @@ func catchSigterm(ws *connection.Conn) {
 	for {
 		// Wait until we receive a SIGTERM.
 		log.Println("received signal: ", <-c)
+		// Notify the receiver that the health score should now be 0.
 		hbm := v2.HeartbeatMessage{
 			Health: &v2.Health{
 				Score: 0,
 			},
 		}
-		// Let the receiver know that the health score should now be 0.
 		err := ws.WriteMessage(websocket.TextMessage, hbm)
 		if err != nil {
 			log.Printf("failed to write final health message, err: %v", err)

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -51,13 +51,13 @@ func Test_main(t *testing.T) {
 		rtx.Must(err, "could not send signal")
 		msg, err = fh.Read()
 		if err != nil {
-			t.Errorf("catchSigterm() did not send message")
+			t.Errorf("write() did not send message")
 		}
 		var hbm v2.HeartbeatMessage
 		err = json.Unmarshal(msg, &hbm)
 		rtx.Must(err, "could not unmarshal message")
 		if hbm.Health.Score != 0 {
-			t.Errorf("catchSigterm() did not send 0 health message")
+			t.Errorf("write() did not send 0 health message")
 		}
 
 		mainCancel()

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -47,7 +47,7 @@ func Test_main(t *testing.T) {
 
 		p, err := os.FindProcess(os.Getpid())
 		rtx.Must(err, "could not get the current process")
-		err = p.Signal(syscall.SIGUSR2)
+		err = p.Signal(syscall.SIGTERM)
 		rtx.Must(err, "could not send signal")
 		msg, err = fh.Read()
 		if err != nil {

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -29,7 +29,6 @@ func Test_main(t *testing.T) {
 	flag.Set("namespace", "default")
 	flag.Set("registration-url", "file:./testdata/registration.json")
 	flag.Set("services", "ndt/ndt7=ws://:"+u.Port()+"/ndt/v7/download")
-	kubernetesAuth = "health/testdata"
 
 	heartbeatPeriod = 2 * time.Second
 	timer := time.NewTimer(2 * heartbeatPeriod)


### PR DESCRIPTION
This PR adds functionality to the heartbeat to handle SIGTERM signals from the OS.

The changes were tested locally by getting the processing id and sending a `kill -15 $pid` signal.

```
$ ./heartbeat     -heartbeat-url=ws://locate-dot-mlab-sandbox.appspot.com/v2/platform/heartbeat?key=${key}     -registration-url=https://siteinfo.mlab-sandbox.measurementlab.net/v2/sites/registration.json     -hostname=ndt-mlab1-lga0t.mlab-sandbox.measurement-lab.org     -services=ndt/ndt7=ws:///ndt/v7/download,ws:///ndt/v7/upload     -services=ndt/ndt7=wss:///ndt/v7/download,wss:///ndt/v7/upload
2023/06/29 19:18:58 successfully established a connection with ws://locate-dot-mlab-sandbox.appspot.com/v2/platform/heartbeat?key=${key}
3976599
Received signal:  terminated
```

Related to https://github.com/m-lab/locate/issues/138.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/141)
<!-- Reviewable:end -->
