### PR TITLE
Add new label to Kubernetes request metric

### DIFF
--- a/cmd/heartbeat/health/kubernetes-client.go
+++ b/cmd/heartbeat/health/kubernetes-client.go
@@ -106,11 +106,11 @@ func (c *KubernetesClient) isPodRunning(ctx context.Context) bool {
 	pod, err := c.clientset.CoreV1().Pods(c.namespace).Get(ctx, c.pod, metav1.GetOptions{})
 	if err != nil {
 		log.Printf("%s: %v", errKubernetesAPI, err)
-		metrics.KubernetesRequestsTotal.WithLabelValues(extractError(err)).Inc()
+		metrics.KubernetesRequestsTotal.WithLabelValues("pod", extractError(err)).Inc()
 		return true
 	}
 
-	metrics.KubernetesRequestsTotal.WithLabelValues("OK").Inc()
+	metrics.KubernetesRequestsTotal.WithLabelValues("pod", "OK").Inc()
 	return pod.Status.Phase == "Running"
 }
 
@@ -123,11 +123,11 @@ func (c *KubernetesClient) isNodeReady(ctx context.Context) bool {
 	node, err := c.clientset.CoreV1().Nodes().Get(ctx, c.node, metav1.GetOptions{})
 	if err != nil {
 		log.Printf("%s: %v", errKubernetesAPI, err)
-		metrics.KubernetesRequestsTotal.WithLabelValues(extractError(err)).Inc()
+		metrics.KubernetesRequestsTotal.WithLabelValues("node", extractError(err)).Inc()
 		return true
 	}
 
-	metrics.KubernetesRequestsTotal.WithLabelValues("OK").Inc()
+	metrics.KubernetesRequestsTotal.WithLabelValues("node", "OK").Inc()
 	for _, condition := range node.Status.Conditions {
 		if condition.Type == "Ready" && condition.Status == "True" {
 			return !isInMaintenance(node)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -131,7 +131,7 @@ var (
 			Name: "heartbeat_kubernetes_requests_total",
 			Help: "Number of requests from the HBS to the Kubernetes API",
 		},
-		[]string{"status"},
+		[]string{"type", "status"},
 	)
 
 	// HealthEndpointChecksTotal counts the number of local /health endpoint

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -17,7 +17,7 @@ func TestLintMetrics(t *testing.T) {
 	MetroDistanceRanking.WithLabelValues("index")
 	ConnectionRequestsTotal.WithLabelValues("status")
 	PortChecksTotal.WithLabelValues("status")
-	KubernetesRequestsTotal.WithLabelValues("status")
+	KubernetesRequestsTotal.WithLabelValues("type", "status")
 	KubernetesRequestTimeHistogram.WithLabelValues("healthy")
 	RegistrationUpdateTime.Set(0)
 	promtest.LintMetrics(nil)


### PR DESCRIPTION
This PR adds a new metric to the Kubernetes request metric to differentiate between pod and node requests.