### PR TITLE
Add histogram for health transmission duration

### DIFF
--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -3,11 +3,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -132,7 +132,7 @@ func write(ws *connection.Conn, hc *health.Checker, ldr *registration.Loader) {
 			sendMessage(ws, hbm, "health")
 
 			// Record duration metric.
-			fmtScore := strconv.FormatFloat(score, 'E', -1, 64)
+			fmtScore := fmt.Sprintf("%.1f", score)
 			metrics.HealthTransmissionDuration.WithLabelValues(fmtScore).Observe(time.Since(t).Seconds())
 		}
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -162,4 +162,14 @@ var (
 			Help: "Time of new registration retrieval from siteinfo.",
 		},
 	)
+
+	// HealthTransmissionDuration is a histogram for the latency of the heartbeat
+	// to assess local health and send it to the Locate.
+	HealthTransmissionDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "heartbeat_health_transmission_duration",
+			Help: "Latency for the heartbeat to assess local health and send it.",
+		},
+		[]string{"score"},
+	)
 )

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -167,8 +167,9 @@ var (
 	// to assess local health and send it to the Locate.
 	HealthTransmissionDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "heartbeat_health_transmission_duration",
-			Help: "Latency for the heartbeat to assess local health and send it.",
+			Name:    "heartbeat_health_transmission_duration",
+			Help:    "Latency for the heartbeat to assess local health and send it.",
+			Buckets: prometheus.LinearBuckets(0, 2, 30),
 		},
 		[]string{"score"},
 	)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -20,5 +20,6 @@ func TestLintMetrics(t *testing.T) {
 	KubernetesRequestsTotal.WithLabelValues("type", "status")
 	KubernetesRequestTimeHistogram.WithLabelValues("healthy")
 	RegistrationUpdateTime.Set(0)
+	HealthTransmissionDuration.WithLabelValues("score")
 	promtest.LintMetrics(nil)
 }


### PR DESCRIPTION
This PR adds a new metric to keep track of how long it takes for the heartbeat to calculate the local health score and send it to the Locate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/147)
<!-- Reviewable:end -->
