### PR TITLE
Change number of buckets for health transmission duration metric

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -169,7 +169,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "heartbeat_health_transmission_duration",
 			Help:    "Latency for the heartbeat to assess local health and send it.",
-			Buckets: prometheus.LinearBuckets(0, 2, 30),
+			Buckets: prometheus.LinearBuckets(0, 2, 16),
 		},
 		[]string{"score"},
 	)


### PR DESCRIPTION
This PR changes the maximum number of buckets for the health transmission histogram since the Memorystore timeout is 30 seconds (2 * 16  = 31 steps from 0 to 30), so the distinction for any latency after that is not relevant (e.g., 32 seconds has the same effect as 40).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/150)
<!-- Reviewable:end -->
