### PR TITLE
Reduce minimum number of VMs to 12

### DIFF
--- a/cloudbuild/app.yaml.mlab-ns.template
+++ b/cloudbuild/app.yaml.mlab-ns.template
@@ -17,7 +17,7 @@ network:
     - 9090/tcp
 
 automatic_scaling:
-  min_num_instances: 12
+  min_num_instances: 9
   max_num_instances: 40
   cool_down_period_sec: 300
 

--- a/cloudbuild/app.yaml.mlab-ns.template
+++ b/cloudbuild/app.yaml.mlab-ns.template
@@ -17,7 +17,7 @@ network:
     - 9090/tcp
 
 automatic_scaling:
-  min_num_instances: 15
+  min_num_instances: 12
   max_num_instances: 40
   cool_down_period_sec: 300
 

--- a/cloudbuild/app.yaml.mlab-ns.template
+++ b/cloudbuild/app.yaml.mlab-ns.template
@@ -17,7 +17,7 @@ network:
     - 9090/tcp
 
 automatic_scaling:
-  min_num_instances: 9
+  min_num_instances: 12
   max_num_instances: 40
   cool_down_period_sec: 300
 


### PR DESCRIPTION
This PR reduces the minimum number of VMs in the mlab-ns project to 12 to safely stay under the CPU quota (120) during deployments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/156)
<!-- Reviewable:end -->
