### PR TITLE
Locate: Increase early-exit probability to 10%

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,7 +34,7 @@ import (
 var (
 	errFailedToLookupClient = errors.New("Failed to look up client location")
 	rand                    = mathx.NewRandom(time.Now().UnixNano())
-	earlyExitProbability    = 0.01
+	earlyExitProbability    = 0.1
 )
 
 // Signer defines how access tokens are signed.


### PR DESCRIPTION
This PR increases the probability of early-exit tests from 1% to 10%. 

The set of checks performed are described under [this](https://github.com/m-lab/ndt-server/issues/395#issuecomment-1726338260) launch issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/160)
<!-- Reviewable:end -->
