### PR TITLE
Extend rate limit period to 15 minutes

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -37,14 +37,14 @@ var (
 	earlyExitProbability    = 0.3
 	tooManyRequests         = "Too many requests per minute. Please contact support@measurementlab.net."
 	limitIntervals          = []limitInterval{
-		{hour: 1, minute: 10},
-		{hour: 4, minute: 10},
-		{hour: 7, minute: 10},
-		{hour: 10, minute: 10},
-		{hour: 13, minute: 10},
-		{hour: 16, minute: 10},
-		{hour: 19, minute: 10},
-		{hour: 22, minute: 10},
+		{hour: 1, minute: 15},
+		{hour: 4, minute: 15},
+		{hour: 7, minute: 15},
+		{hour: 10, minute: 15},
+		{hour: 13, minute: 15},
+		{hour: 16, minute: 15},
+		{hour: 19, minute: 15},
+		{hour: 22, minute: 15},
 	}
 )
 


### PR DESCRIPTION
This PR extends the rate limit period for the 3-hour client to 15 minutes past the hour. There seems to be a retry period that extends a little bit over 10 minutes.

[Prometheus](https://prometheus.mlab-oti.measurementlab.net/graph?g0.expr=sum%20by%20(status)%20(rate(locate_requests_total%7Btype%3D%22nearest%22%7D%5B2m%5D))&g0.tab=0&g0.stacked=0&g0.show_exemplars=0&g0.range_input=14m6s177ms&g0.end_input=2023-10-02%2022%3A16%3A01&g0.moment_input=2023-10-02%2022%3A16%3A01) shows a spike in the "OK" requests right after the 10 minute mark.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/163)
<!-- Reviewable:end -->
