### PR TITLE
Locate: Increase early-exit probability to 50%

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,7 +34,7 @@ import (
 var (
 	errFailedToLookupClient = errors.New("Failed to look up client location")
 	rand                    = mathx.NewRandom(time.Now().UnixNano())
-	earlyExitProbability    = 0.3
+	earlyExitProbability    = 0.5
 	tooManyRequests         = "Too many requests per minute. Please contact support@measurementlab.net."
 	limitIntervals          = []limitInterval{
 		{hour: 1, minute: 15},


### PR DESCRIPTION
This PR increases the probability of early-exit tests from 30% to 50%.

The set of checks performed are described under the [launch issue](https://github.com/m-lab/ndt-server/issues/395#issuecomment-1745617873).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/164)
<!-- Reviewable:end -->
