### PR TITLE
Add result index parameter to URLs

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -114,7 +114,7 @@ func NewClientDirect(project string, private Signer, locator Locator, locatorV2 
 	}
 }
 
-func extraParams(hostname string, p paramOpts) url.Values {
+func extraParams(hostname string, index int, p paramOpts) url.Values {
 	v := url.Values{}
 	// Add client parameters.
 	for key := range p.raw {
@@ -135,6 +135,9 @@ func extraParams(hostname string, p paramOpts) url.Values {
 	if ok {
 		v.Set("metro_rank", strconv.Itoa(rank))
 	}
+
+	// Add result index.
+	v.Set("index", strconv.Itoa(index))
 
 	return v
 }
@@ -274,7 +277,7 @@ func (c *Client) checkClientLocation(rw http.ResponseWriter, req *http.Request) 
 func (c *Client) populateURLs(targets []v2.Target, ports static.Ports, exp string, pOpts paramOpts) {
 	for i, target := range targets {
 		token := c.getAccessToken(target.Machine, exp)
-		params := extraParams(target.Machine, pOpts)
+		params := extraParams(target.Machine, i, pOpts)
 		targets[i].URLs = c.getURLs(ports, target.Machine, exp, token, params)
 	}
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -478,6 +478,7 @@ func TestExtraParams(t *testing.T) {
 	tests := []struct {
 		name                 string
 		hostname             string
+		index                int
 		p                    paramOpts
 		earlyExitProbability float64
 		want                 url.Values
@@ -485,6 +486,7 @@ func TestExtraParams(t *testing.T) {
 		{
 			name:     "all-params",
 			hostname: "host",
+			index:    0,
 			p: paramOpts{
 				raw:     map[string][]string{"client_name": {"client"}},
 				version: "v2",
@@ -494,11 +496,13 @@ func TestExtraParams(t *testing.T) {
 				"client_name":    []string{"client"},
 				"locate_version": []string{"v2"},
 				"metro_rank":     []string{"0"},
+				"index":          []string{"0"},
 			},
 		},
 		{
 			name:     "no-client",
 			hostname: "host",
+			index:    0,
 			p: paramOpts{
 				version: "v2",
 				ranks:   map[string]int{"host": 0},
@@ -506,21 +510,25 @@ func TestExtraParams(t *testing.T) {
 			want: url.Values{
 				"locate_version": []string{"v2"},
 				"metro_rank":     []string{"0"},
+				"index":          []string{"0"},
 			},
 		},
 		{
 			name:     "unmatched-host",
 			hostname: "host",
+			index:    0,
 			p: paramOpts{
 				version: "v2",
 				ranks:   map[string]int{"different-host": 0},
 			},
 			want: url.Values{
 				"locate_version": []string{"v2"},
+				"index":          []string{"0"},
 			},
 		},
 		{
-			name: "early-exit-true",
+			name:  "early-exit-true",
+			index: 0,
 			p: paramOpts{
 				raw:     map[string][]string{"early_exit": {"250"}},
 				version: "v2",
@@ -529,10 +537,12 @@ func TestExtraParams(t *testing.T) {
 			want: url.Values{
 				"early_exit":     []string{"250"},
 				"locate_version": []string{"v2"},
+				"index":          []string{"0"},
 			},
 		},
 		{
-			name: "early-exit-false",
+			name:  "early-exit-false",
+			index: 0,
 			p: paramOpts{
 				raw:     map[string][]string{"early_exit": {"250"}},
 				version: "v2",
@@ -540,13 +550,14 @@ func TestExtraParams(t *testing.T) {
 			earlyExitProbability: 0,
 			want: url.Values{
 				"locate_version": []string{"v2"},
+				"index":          []string{"0"},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			earlyExitProbability = tt.earlyExitProbability
-			got := extraParams(tt.hostname, tt.p)
+			got := extraParams(tt.hostname, tt.index, tt.p)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("extraParams() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
This PR adds a new result "index" parameter to the set of returned URLs to have visibility into potential failovers on the client side.

Sample result from https://locate-dot-mlab-sandbox.appspot.com/v2/nearest/ndt/ndt7: "ws://ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjItbGdhMXQubWxhYi1zYW5kYm94Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjk5NDU3NTY5LCJpc3MiOiJsb2NhdGUiLCJqdGkiOiJmMzk2ZDYyNy1lMDNlLTQ4YjMtOGM0Mi1mNjAzOWNhNGVjMDAiLCJzdWIiOiJuZHQifQ.S2QjfZdFt-JJCZcKtzfvEXF9IYUJ9QmayfzgOWJAb4PSRw0tCU8fkR_LdfzGRcdeHrcy4f0fBOayqsLvpQKKBw\u0026**index=0** \u0026locate_version=v2\u0026metro_rank=0"

Related to https://github.com/m-lab/ops-tracker/issues/1859

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/166)
<!-- Reviewable:end -->
