### PR TITLE
Increase early exit probability to 90%

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -34,7 +34,7 @@ import (
 var (
 	errFailedToLookupClient = errors.New("Failed to look up client location")
 	rand                    = mathx.NewRandom(time.Now().UnixNano())
-	earlyExitProbability    = 0.5
+	earlyExitProbability    = 0.9
 )
 
 // Signer defines how access tokens are signed.


### PR DESCRIPTION
This PR increases the probability of early-exit tests from 50% to 90%.

The set of checks performed are described under the launch issue ([1](https://github.com/m-lab/ndt-server/issues/395#issuecomment-1806005414), [2](https://github.com/m-lab/ndt-server/issues/395#issuecomment-1806027426)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/167)
<!-- Reviewable:end -->
