### PR TITLE
Passes a rate of 6 to the exponentially distributed selection function

### DIFF
--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -223,7 +223,9 @@ func pickTargets(service string, sites []site) *TargetInfo {
 	var urls []url.URL
 
 	for i := 0; i < numTargets; i++ {
-		index := mathx.GetExpDistributedInt(1) % len(sites)
+		// A rate of 6 yields index 0 around 95% of the time, index 1 a little less
+		// than 5% of the time, and higher indexes infrequently.
+		index := mathx.GetExpDistributedInt(6) % len(sites)
 		s := sites[index]
 		metrics.ServerDistanceRanking.WithLabelValues(strconv.Itoa(i)).Observe(float64(s.rank))
 		metrics.MetroDistanceRanking.WithLabelValues(strconv.Itoa(i)).Observe(float64(s.metroRank))

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -224,7 +224,7 @@ func pickTargets(service string, sites []site) *TargetInfo {
 
 	for i := 0; i < numTargets; i++ {
 		// A rate of 6 yields index 0 around 95% of the time, index 1 a little less
-		// than 5% of the time, and higher indexes infrequently.
+		// than 5% of the time, and higher indices infrequently.
 		index := mathx.GetExpDistributedInt(6) % len(sites)
 		s := sites[index]
 		metrics.ServerDistanceRanking.WithLabelValues(strconv.Itoa(i)).Observe(float64(s.rank))

--- a/heartbeat/location_test.go
+++ b/heartbeat/location_test.go
@@ -760,7 +760,15 @@ func TestPickTargets(t *testing.T) {
 			expected: &TargetInfo{
 				Targets: []v2.Target{
 					{
-						Machine: "mlab2-site1-metro0",
+						Machine: "mlab2-site2-metro0",
+						Location: &v2.Location{
+							City:    site2.registration.City,
+							Country: site2.registration.CountryCode,
+						},
+						URLs: make(map[string]string),
+					},
+					{
+						Machine: "mlab3-site1-metro0",
 						Location: &v2.Location{
 							City:    site1.registration.City,
 							Country: site1.registration.CountryCode,
@@ -776,14 +784,6 @@ func TestPickTargets(t *testing.T) {
 						URLs: make(map[string]string),
 					},
 					{
-						Machine: "mlab4-site2-metro0",
-						Location: &v2.Location{
-							City:    site2.registration.City,
-							Country: site2.registration.CountryCode,
-						},
-						URLs: make(map[string]string),
-					},
-					{
 						Machine: "mlab1-site4-metro2",
 						Location: &v2.Location{
 							City:    site4.registration.City,
@@ -794,10 +794,10 @@ func TestPickTargets(t *testing.T) {
 				},
 				URLs: NDT7Urls,
 				Ranks: map[string]int{
-					"mlab2-site1-metro0": 0,
 					"mlab1-site3-metro1": 1,
-					"mlab4-site2-metro0": 0,
 					"mlab1-site4-metro2": 2,
+					"mlab2-site2-metro0": 0,
+					"mlab3-site1-metro0": 0,
 				},
 			},
 		},


### PR DESCRIPTION
I tested using this small Go program:

```
package main

import (
	"fmt"
	"time"

	"github.com/m-lab/go/mathx"
)

func main() {
	r := mathx.NewRandom(time.Now().UnixNano())

	for rate := 1; rate < 7; rate++ {
		keys := make(map[int]int)
		for i := 0; i < 10000000; i++ {
			index := r.GetExpDistributedInt(float64(rate)) % 5
			keys[index]++
		}
		fmt.Printf("Rate %d: %v\n", rate, keys)
	}
}
```

... which yields something like:

```
$ go run main.go 
Rate 1: map[0:4004697 1:3860959 2:1419117 3:522604 4:192623]
Rate 2: map[0:6323166 1:3180105 2:430647 3:58221 4:7861]
Rate 3: map[0:7769307 1:2119101 2:106222 3:5116 4:254]
Rate 4: map[0:8647798 1:1327257 2:24507 3:427 4:11]
Rate 5: map[0:9179218 1:815219 2:5525 3:38]
Rate 6: map[0:9501968 1:496809 2:1219 3:4]
```

A rate of 6 appears to return an index of 0 ~95% of the time, an index 1 about the other 5% of the time, and higher indices rather infrequently. This seems like around where we want the distribution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/173)
<!-- Reviewable:end -->
