### PR TITLE
Add "strict" querystring parameter

### DIFF
--- a/clientgeo/user.go
+++ b/clientgeo/user.go
@@ -54,7 +54,12 @@ func (u *UserLocator) Locate(req *http.Request) (*Location, error) {
 		loc.Headers.Set(hLocateClientlatlonMethod, "user-region")
 		return loc, err
 	}
-	if ll, ok := static.Countries[req.URL.Query().Get("country")]; ok {
+
+	// If the user requested a specific country without strict=true, set the
+	// lat/lon to the geographic center of that country. If the user requested
+	// a specific country with strict=true, keep lat/lon as it is.
+	if ll, ok := static.Countries[req.URL.Query().Get("country")]; ok &&
+		req.URL.Query().Get("strict") != "true" {
 		loc, err := splitLatLon(ll)
 		loc.Headers.Set(hLocateClientlatlon, ll)
 		loc.Headers.Set(hLocateClientlatlonMethod, "user-country")

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -179,7 +179,11 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 	t := q.Get("machine-type")
 	country := req.Header.Get("X-AppEngine-Country")
 	sites := q["site"]
-	opts := &heartbeat.NearestOptions{Type: t, Country: country, Sites: sites}
+	strict := false
+	if qsStrict, err := strconv.ParseBool(q.Get("strict")); err == nil {
+		strict = qsStrict
+	}
+	opts := &heartbeat.NearestOptions{Type: t, Country: country, Sites: sites, Strict: strict}
 	targetInfo, err := c.LocatorV2.Nearest(service, lat, lon, opts)
 	if err != nil {
 		result.Error = v2.NewError("nearest", "Failed to lookup nearest machines", http.StatusInternalServerError)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -183,6 +183,11 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 	if qsStrict, err := strconv.ParseBool(q.Get("strict")); err == nil {
 		strict = qsStrict
 	}
+	// If strict, override the country from the AppEngine header with the one in
+	// the querystring.
+	if strict {
+		country = q.Get("country")
+	}
 	opts := &heartbeat.NearestOptions{Type: t, Country: country, Sites: sites, Strict: strict}
 	targetInfo, err := c.LocatorV2.Nearest(service, lat, lon, opts)
 	if err != nil {

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -2,7 +2,6 @@ package heartbeat
 
 import (
 	"errors"
-	"log"
 	"math/rand"
 	"net/url"
 	"sort"
@@ -154,7 +153,6 @@ func isValidInstance(service string, lat, lon float64, v v2.HeartbeatMessage, op
 		return false, host.Name{}, 0
 	}
 
-	log.Printf("country %s, strict: %v\n", opts.Country, opts.Strict)
 	if opts.Country != "" && opts.Strict {
 		if r.CountryCode != opts.Country {
 			return false, host.Name{}, 0

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -2,6 +2,7 @@ package heartbeat
 
 import (
 	"errors"
+	"log"
 	"math/rand"
 	"net/url"
 	"sort"
@@ -153,6 +154,7 @@ func isValidInstance(service string, lat, lon float64, v v2.HeartbeatMessage, op
 		return false, host.Name{}, 0
 	}
 
+	log.Printf("country %s, strict: %v\n", opts.Country, opts.Strict)
 	if opts.Country != "" && opts.Strict {
 		if r.CountryCode != opts.Country {
 			return false, host.Name{}, 0

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -30,6 +30,7 @@ type NearestOptions struct {
 	Type    string   // Limit results to only machines of this type.
 	Sites   []string // Limit results to only machines at these sites.
 	Country string   // Bias results to prefer machines in this country.
+	Strict  bool     // When used with Country, limit results to only machines in this country.
 }
 
 // TargetInfo returns the set of `v2.Target` to run the measurement on with the
@@ -150,6 +151,12 @@ func isValidInstance(service string, lat, lon float64, v v2.HeartbeatMessage, op
 
 	if opts.Sites != nil && !contains(opts.Sites, r.Site) {
 		return false, host.Name{}, 0
+	}
+
+	if opts.Country != "" && opts.Strict {
+		if r.CountryCode != opts.Country {
+			return false, host.Name{}, 0
+		}
 	}
 
 	if _, ok := r.Services[service]; !ok {

--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -153,10 +153,8 @@ func isValidInstance(service string, lat, lon float64, v v2.HeartbeatMessage, op
 		return false, host.Name{}, 0
 	}
 
-	if opts.Country != "" && opts.Strict {
-		if r.CountryCode != opts.Country {
-			return false, host.Name{}, 0
-		}
+	if opts.Country != "" && opts.Strict && r.CountryCode != opts.Country {
+		return false, host.Name{}, 0
 	}
 
 	if _, ok := r.Services[service]; !ok {

--- a/heartbeat/location_test.go
+++ b/heartbeat/location_test.go
@@ -332,6 +332,28 @@ func TestNearest(t *testing.T) {
 			expected: nil,
 			wantErr:  true,
 		},
+		{
+			name:    "NDT7-any-type-country",
+			service: "ndt/ndt7",
+			lat:     43.1988,
+			lon:     -75.3242,
+			opts:    &NearestOptions{Type: "", Country: "IT"},
+			expected: &TargetInfo{
+				Targets: []v2.Target{virtualTarget, physicalTarget},
+				URLs:    NDT7Urls,
+				Ranks:   map[string]int{virtualTarget.Machine: 0, physicalTarget.Machine: 1},
+			},
+			wantErr: false,
+		},
+		{
+			name:     "NDT7-any-type-country-strict",
+			service:  "ndt/ndt7",
+			lat:      43.1988,
+			lon:      -75.3242,
+			opts:     &NearestOptions{Type: "", Country: "IT", Strict: true},
+			expected: nil,
+			wantErr:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -350,7 +372,7 @@ func TestNearest(t *testing.T) {
 			got, err := locator.Nearest(tt.service, tt.lat, tt.lon, tt.opts)
 
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("Nearest() error got: %t, want %t", err != nil, tt.wantErr)
+				t.Fatalf("Nearest() error got: %t, want %t, err: %v", err != nil, tt.wantErr, err)
 			}
 
 			if !reflect.DeepEqual(got, tt.expected) {
@@ -374,6 +396,7 @@ func TestFilterSites(t *testing.T) {
 		service  string
 		typ      string
 		country  string
+		strict   bool
 		lat      float64
 		lon      float64
 		expected []site
@@ -423,11 +446,31 @@ func TestFilterSites(t *testing.T) {
 			lon:      1000,
 			expected: []site{},
 		},
+		{
+			name:     "country-with-strict",
+			service:  "ndt/ndt7",
+			typ:      "",
+			country:  "US",
+			strict:   true,
+			lat:      43.1988,
+			lon:      -75.3242,
+			expected: []site{virtualSite, physicalSite},
+		},
+		{
+			name:     "country-with-strict-no-results",
+			service:  "ndt/ndt7",
+			typ:      "",
+			country:  "IT",
+			strict:   true,
+			lat:      43.1988,
+			lon:      -75.3242,
+			expected: []site{},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts := &NearestOptions{Type: tt.typ, Country: tt.country}
+			opts := &NearestOptions{Type: tt.typ, Country: tt.country, Strict: tt.strict}
 			got := filterSites(tt.service, tt.lat, tt.lon, instances, opts)
 
 			sortSites(got)


### PR DESCRIPTION
The default behavior when the `country` parameter is provided is to override client location with the geographical center of the requested country, then apply the normal algorithm to find the nearest servers. 

This PR adds the `strict` parameter which, when used in conjunction with `country`, limits the results to servers in the requested country and _does not_ override the client location.

Examples: 
  - `country=GB` - returns servers that are the closest to GB's geographical center (even if they happen to be outside GB)
  - `country=GB&strict=true` - returns servers that are closest to the user's location, but strictly in GB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/177)
<!-- Reviewable:end -->
