### PR TITLE
Label the Locate API name with deployment environment

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
     app.yaml
   - gcloud --project $PROJECT_ID app deploy --promote app.yaml
   # After deploying the new service, deploy the openapi spec.
-  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' openapi.yaml
+  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
   - gcloud endpoints services deploy openapi.yaml
 
 # Deployment of APIs in mlab-ns.
@@ -50,5 +50,5 @@ steps:
     app.yaml
   - gcloud --project $PROJECT_ID app deploy --promote app.yaml
   # After deploying the new service, deploy the openapi spec.
-  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' openapi.yaml
+  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/Production/' openapi.yaml
   - gcloud endpoints services deploy openapi.yaml

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -18,7 +18,7 @@ info:
   description: |-
     The locate API provides consistent, expected measurement quality for M-Lab
     clients.
-  title: "M-Lab Locate API"
+  title: "M-Lab Locate API ({{DEPLOYMENT}})"
   version: "2.0.0"
 host: "locate-dot-{{PROJECT}}.appspot.com"
 # [END swagger]


### PR DESCRIPTION
This change labels the deployment environment with the sandbox or staging project name or simply "Production" for M-Lab's production environment.

This change will help us distinguish between the different deployments internally, and signal to third parties that the "Production" API is for production use.

Without:
<img width="673" alt="Screenshot 2024-02-05 at 11 32 42 AM" src="https://github.com/m-lab/locate/assets/1085316/37d0491e-9104-4d5e-bf2d-a8fd1287e798">

With:
<img width="661" alt="Screenshot 2024-02-05 at 11 56 32 AM" src="https://github.com/m-lab/locate/assets/1085316/f0d0e631-58ed-471f-b402-3aed13442b61">


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/178)
<!-- Reviewable:end -->
