### PR TITLE
Remove obsolete test logic

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -3,7 +3,6 @@
 package handler
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -43,18 +42,6 @@ func (s *fakeSigner) Sign(cl jwt.Claims) (string, error) {
 		cl.Audience[0], cl.Subject, cl.Issuer, cl.Expiry.Time().Format(time.RFC3339),
 	}, "--")
 	return t, nil
-}
-
-type fakeLocator struct {
-	err     error
-	targets []v2.Target
-}
-
-func (l *fakeLocator) Nearest(ctx context.Context, service, lat, lon string) ([]v2.Target, error) {
-	if l.err != nil {
-		return nil, l.err
-	}
-	return l.targets, nil
 }
 
 type fakeLocatorV2 struct {


### PR DESCRIPTION
This change removes a fake locator previously used in tests and now obsolete. Should have been removed by https://github.com/m-lab/locate/pull/172

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/186)
<!-- Reviewable:end -->
