### PR TITLE
Support autojoin hostnames in registration.json

### DIFF
--- a/cmd/heartbeat/registration/registration.go
+++ b/cmd/heartbeat/registration/registration.go
@@ -68,7 +68,13 @@ func (ldr *Loader) GetRegistration(ctx context.Context) (*v2.Registration, error
 		return nil, err
 	}
 
-	if v, ok := registrations[ldr.hostname.String()]; ok {
+	// The registration key can be both a hostname or a hostname with a service,
+	// so the following code checks for both, with priority to hostnames w/o service.
+	v, ok := registrations[ldr.hostname.String()]
+	if !ok {
+		v, ok = registrations[ldr.hostname.StringWithService()]
+	}
+	if ok {
 		v.Hostname = ldr.hostname.StringWithService()
 		// If the registration has not changed, there is nothing new to return.
 		if cmp.Equal(ldr.reg, v) {

--- a/cmd/heartbeat/registration/registration_test.go
+++ b/cmd/heartbeat/registration/registration_test.go
@@ -16,6 +16,7 @@ import (
 var (
 	validHostname           = "ndt-mlab1-lga0t.mlab-sandbox.measurement-lab.org"
 	validHostnameWithSuffix = "ndt-mlab1-lga0t.mlab-sandbox.measurement-lab.org-t95j"
+	validAutojoinHostname   = "ndt-lga12345-1a2b3c4d.mlab.sandbox.measurement-lab.org"
 	validURL                = "file:./testdata/registration.json"
 	validMsg                = &v2.Registration{
 		City:          "New York",
@@ -31,6 +32,21 @@ var (
 		Site:          "lga0t",
 		Type:          "physical",
 		Uplink:        "10g",
+	}
+	validAutojoinMsg = &v2.Registration{
+		City:          "New York",
+		CountryCode:   "US",
+		ContinentCode: "NA",
+		Hostname:      "ndt-lga12345-1a2b3c4d.mlab.sandbox.measurement-lab.org",
+		Latitude:      40.775,
+		Longitude:     -73.875,
+		Machine:       "1a2b3c4d",
+		Metro:         "lga",
+		Project:       "mlab-sandbox",
+		Probability:   1,
+		Site:          "lga12345",
+		Type:          "unknown",
+		Uplink:        "unknown",
 	}
 )
 
@@ -202,6 +218,22 @@ func Test_GetRegistration(t *testing.T) {
 			wantMsg:      nil,
 			wantSavedReg: v2.Registration{},
 		},
+		{
+			name:         "priority-to-non-service-key",
+			url:          validURL,
+			hostname:     validHostname,
+			wantErr:      false,
+			wantMsg:      validMsg,
+			wantSavedReg: *validMsg,
+		},
+		{
+			name:         "valid-autojoin-hostname-data",
+			url:          validURL,
+			hostname:     validAutojoinHostname,
+			wantErr:      false,
+			wantMsg:      validAutojoinMsg,
+			wantSavedReg: *validAutojoinMsg,
+		},
 	}
 
 	for _, tt := range tests {
@@ -224,7 +256,7 @@ func Test_GetRegistration(t *testing.T) {
 			}
 
 			if diff := deep.Equal(gotMsg, tt.wantMsg); diff != nil {
-				t.Errorf("GetRegistration() message did not match; got: %+v, want: %+v", gotMsg, tt.wantMsg)
+				t.Errorf("GetRegistration() message did not match; got: \n%+v, want: \n%+v", gotMsg, tt.wantMsg)
 			}
 
 			if diff := deep.Equal(ldr.reg, tt.wantSavedReg); diff != nil {

--- a/cmd/heartbeat/registration/testdata/registration.json
+++ b/cmd/heartbeat/registration/testdata/registration.json
@@ -1,5 +1,5 @@
 {
-  "mlab1-lga0t.mlab-sandbox.measurement-lab.org": {
+   "mlab1-lga0t.mlab-sandbox.measurement-lab.org": {
       "City": "New York",
       "ContinentCode": "NA",
       "CountryCode": "US",
@@ -11,5 +11,33 @@
       "Site": "lga0t",
       "Type": "physical",
       "Uplink": "10g"
+   },
+   "ndt-mlab1-lga0t.mlab-sandbox.measurement-lab.org": {
+      "City": "New York",
+      "ContinentCode": "NA",
+      "CountryCode": "US",
+      "Latitude": 40.7667,
+      "Longitude": -73.8667,
+      "Machine": "mlab1-withservice",
+      "Metro": "lga",
+      "Project": "mlab-sandbox",
+      "Site": "lga0t",
+      "Type": "physical",
+      "Uplink": "10g"
+   },
+   "ndt-lga12345-1a2b3c4d.mlab.sandbox.measurement-lab.org": {
+      "City": "New York",
+      "CountryCode": "US",
+      "ContinentCode": "NA",
+      "Hostname": "ndt-lga12345-1a2b3c4d.mlab.sandbox.measurement-lab.org",
+      "Latitude": 40.775,
+      "Longitude": -73.875,
+      "Machine": "1a2b3c4d",
+      "Metro": "lga",
+      "Project": "mlab-sandbox",
+      "Probability": 1,
+      "Site": "lga12345",
+      "Type": "unknown",
+      "Uplink": "unknown"
    }
 }


### PR DESCRIPTION
Hostnames registered via the [autojoin](https://github.com/m-lab/autojoin) service always include a service prefix. This PR makes heartbeat check for both "w/ service" and "w/o service" keys in registration.json so that it will be able to work with autojoin hostnames.

e.g. registration.json:
```
{
  "ndt-lga46450-8e9ad576.mlab.sandbox.measurement-lab.org": {
    [...]
  }
}
```
`$ ./heartbeat -registration-url=registration.json -hostname ndt-lga46450-8e9ad576.mlab.sandbox.measurement-lab.org`

This would previously fail because heartbeat checks for `lga46450...` stripping the `ndt-` prefix in registration.json. 

In the (unlikely) case that both w/service and w/o service keys are present in registration.json, the one without a service prefix takes precedence.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/187)
<!-- Reviewable:end -->
