### PR TITLE
 Reads value of var lbPath (/metadata/loadbalanced)

### DIFF
--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -99,9 +99,7 @@ func main() {
 	var hc Checker
 
 	lbbytes, lberr := os.ReadFile(lbPath)
-	if lberr != nil {
-		rtx.Must(err, "failed to read the value of metadata file 'loadbalanced'")
-	}
+	rtx.Must(lberr, "failed to read metadata file 'loadbalanced'")
 
 	// If the "loadbalanced" file exists, then the instance is a load balanced VM.
 	// If not, then it is a standalone instance.

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -108,7 +108,7 @@ func main() {
 	// If the "loadbalanced" file exists, then make sure that the content of the
 	// file is "true". If the file doesn't exist, then, for now, just consider
 	// the machine as not loadbalanced.
-	if string(lbbytes) == "true" && lberr == nil {
+	if lberr == nil && string(lbbytes) == "true" {
 		gcpmd, err := metadata.NewGCPMetadata(md.NewClient(http.DefaultClient), hostname)
 		rtx.Must(err, "failed to get VM metadata")
 		gceClient, err := compute.NewRegionBackendServicesRESTClient(mainCtx)

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -105,8 +105,9 @@ func main() {
 	// completes in 4 or 5 days, as of this comment 2024-08-06.
 	lbbytes, lberr := os.ReadFile(lbPath)
 
-	// If the "loadbalanced" file exists, then the instance is a load balanced VM.
-	// If not, then it is a standalone instance.
+	// If the "loadbalanced" file exists, then make sure that the content of the
+	// file is "true". If the file doesn't exist, then, for now, just consider
+	// the machine as not loadbalanced.
 	if string(lbbytes) == "true" && lberr == nil {
 		gcpmd, err := metadata.NewGCPMetadata(md.NewClient(http.DefaultClient), hostname)
 		rtx.Must(err, "failed to get VM metadata")

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -22,6 +23,10 @@ func Test_main(t *testing.T) {
 	defer s.Close()
 	u, err := url.Parse(s.URL)
 	rtx.Must(err, "could not parse server URL")
+
+	lbPath = "/tmp/loadbalanced"
+	os.WriteFile(lbPath, []byte("false"), 0644)
+	defer os.Remove(lbPath)
 
 	flag.Set("heartbeat-url", s.URL)
 	flag.Set("hostname", "ndt-mlab1-lga0t.mlab-sandbox.measurement-lab.org")


### PR DESCRIPTION
Previously, the file /metadata/loadbalanced only existed on MIG instances. We recently decided that the file should exist on every machine with either a "true" or "false" value. Locate was only checking for the file's existence to determine if the machine was loadbalanced or not, but since this is no longer a valid signal, this commit causes heartbeat to read the value of the file, and only treat the machine as loadbalanced if the value is "true".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/191)
<!-- Reviewable:end -->
