### PR TITLE
Add max_elapsed_time to service parameters

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -428,6 +428,28 @@ func TestExtraParams(t *testing.T) {
 				"index":                     []string{"0"},
 			},
 		},
+		{
+			name:  "max-cwnd-gain-and-max-elapsed-time-true",
+			index: 0,
+			p: paramOpts{
+				raw: map[string][]string{
+					static.MaxCwndGainParameter:    {"512"},
+					static.MaxElapsedTimeParameter: {"5"},
+				},
+				version: "v2",
+				svcParams: map[string]float64{
+					static.MaxElapsedTimeParameter: 1,
+					static.MaxCwndGainParameter:    1,
+				},
+			},
+			earlyExitProbability: 1,
+			want: url.Values{
+				static.MaxCwndGainParameter:    []string{"512"},
+				static.MaxElapsedTimeParameter: []string{"5"},
+				"locate_version":               []string{"v2"},
+				"index":                        []string{"0"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/static/configs.go
+++ b/static/configs.go
@@ -31,6 +31,7 @@ const (
 	EarthHalfCircumferenceKm   = 20038
 	EarlyExitParameter         = "early_exit"
 	MaxCwndGainParameter       = "max_cwnd_gain"
+	MaxElapsedTimeParameter    = "max_elapsed_time"
 )
 
 // URL creates inline url.URLs.
@@ -45,8 +46,9 @@ func URL(scheme, port, path string) url.URL {
 // ServiceParams is a map of common parameters passed in by services (as URL params)
 // with corresponding probabilities set by the Locate.
 var ServiceParams = map[string]float64{
-	EarlyExitParameter:   0.9,
-	MaxCwndGainParameter: 1,
+	EarlyExitParameter:      0.9,
+	MaxCwndGainParameter:    1,
+	MaxElapsedTimeParameter: 1,
 }
 
 // Configs is a temporary, static mapping of service names and their set of


### PR DESCRIPTION
This PR adds the `max_elapsed_time` client parameter to the Locate's service parameters map to be able to pass it to the server in the URL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/193)
<!-- Reviewable:end -->
