### PR TITLE
Encapsulate SecretClient in NewConfig

### DIFF
--- a/secrets/load_local.go
+++ b/secrets/load_local.go
@@ -19,7 +19,7 @@ func NewLocalConfig() *LocalConfig {
 }
 
 // LoadSigner reads the secret from the named file. The client parameter is ignored.
-func (c *LocalConfig) LoadSigner(ctx context.Context, client SecretClient, name string) (*token.Signer, error) {
+func (c *LocalConfig) LoadSigner(ctx context.Context, name string) (*token.Signer, error) {
 	key, err := ioutil.ReadFile(name)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func (c *LocalConfig) LoadSigner(ctx context.Context, client SecretClient, name 
 }
 
 // LoadVerifier reads the secret from the named file. The client parameter is ignored.
-func (c *LocalConfig) LoadVerifier(ctx context.Context, client SecretClient, name string) (*token.Verifier, error) {
+func (c *LocalConfig) LoadVerifier(ctx context.Context, name string) (*token.Verifier, error) {
 	// TODO: consider supporting `name` as glob to load multiple verifier keys.
 	key, err := ioutil.ReadFile(name)
 	if err != nil {
@@ -39,7 +39,7 @@ func (c *LocalConfig) LoadVerifier(ctx context.Context, client SecretClient, nam
 
 // LoadPrometheus reads the username and password secrets from the named files.
 // The client parameter is ignored.
-func (c *LocalConfig) LoadPrometheus(ctx context.Context, client SecretClient, user, pass string) (*prometheus.Credentials, error) {
+func (c *LocalConfig) LoadPrometheus(ctx context.Context, user, pass string) (*prometheus.Credentials, error) {
 	u, err := ioutil.ReadFile(user)
 	if err != nil {
 		return nil, err

--- a/secrets/load_local_test.go
+++ b/secrets/load_local_test.go
@@ -33,7 +33,7 @@ func TestLocalConfig_LoadSigner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := secrets.NewLocalConfig()
 			ctx := context.Background()
-			_, err := c.LoadSigner(ctx, nil, tt.file)
+			_, err := c.LoadSigner(ctx, tt.file)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LocalConfig.LoadSigner() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -67,7 +67,7 @@ func TestLocalConfig_LoadVerifier(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := secrets.NewLocalConfig()
 			ctx := context.Background()
-			_, err := c.LoadVerifier(ctx, nil, tt.file)
+			_, err := c.LoadVerifier(ctx, tt.file)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LocalConfig.LoadVerifier() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -117,7 +117,7 @@ func TestLocalConfig_LoadPrometheus(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := secrets.NewLocalConfig()
 			ctx := context.Background()
-			got, err := c.LoadPrometheus(ctx, nil, tt.userFile, tt.passFile)
+			got, err := c.LoadPrometheus(ctx, tt.userFile, tt.passFile)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("LocalConfig.LoadPrometheus() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/secrets/load_test.go
+++ b/secrets/load_test.go
@@ -71,9 +71,6 @@ func (f *fakeIter) incrementIdx() {
 func Test_getSecret(t *testing.T) {
 	ctx := context.Background()
 
-	cfg := NewConfig("mlab-sandbox")
-	cfg.iter = &fakeIter{}
-
 	var secretData [][]byte
 	secretData = append(secretData, []byte("fake-secret"))
 
@@ -93,8 +90,10 @@ func Test_getSecret(t *testing.T) {
 			data:    secretData,
 			wantErr: tt.wantErr,
 		}
+		cfg := NewConfig("mlab-sandbox", client)
+		cfg.iter = &fakeIter{}
 
-		secret, err := cfg.getSecret(ctx, client, "fake-path")
+		secret, err := cfg.getSecret(ctx, "fake-path")
 
 		if (err != nil) != tt.wantErr {
 			t.Fatalf("Got error: %v, but wantErr is %v", err, tt.wantErr)
@@ -111,8 +110,8 @@ func Test_getSecret(t *testing.T) {
 
 func Test_getSecretVersions(t *testing.T) {
 	ctx := context.Background()
-	cfg := NewConfig("mlab-sandbox")
 	client := &fakeSecretClient{}
+	cfg := NewConfig("mlab-sandbox", client)
 
 	tests := []struct {
 		name             string
@@ -171,7 +170,7 @@ func Test_getSecretVersions(t *testing.T) {
 			wantErr:  tt.wantIterErr,
 			versions: tt.versions,
 		}
-		versions, err := cfg.getSecretVersions(ctx, client, "test")
+		versions, err := cfg.getSecretVersions(ctx, "test")
 
 		if (err != nil) != tt.wantErr {
 			t.Fatalf("Got error: %v, but wantErr is %v", err, tt.wantErr)
@@ -192,9 +191,6 @@ func Test_getSecretVersions(t *testing.T) {
 
 func Test_LoadSigner(t *testing.T) {
 	ctx := context.Background()
-
-	cfg := NewConfig("mlab-sandbox")
-	cfg.iter = &fakeIter{}
 
 	var signerKeys [][]byte
 
@@ -267,8 +263,9 @@ func Test_LoadSigner(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		cfg := NewConfig("mlab-sandbox", tt.client)
 		cfg.iter = tt.iter
-		_, err := cfg.LoadSigner(ctx, tt.client, "test")
+		_, err := cfg.LoadSigner(ctx, "test")
 
 		if (err != nil) != tt.wantErr {
 			t.Fatalf("Got error: %v, but wantErr is %v", err, tt.wantErr)
@@ -278,9 +275,6 @@ func Test_LoadSigner(t *testing.T) {
 
 func Test_LoadVerifier(t *testing.T) {
 	ctx := context.Background()
-
-	cfg := NewConfig("mlab-sandbox")
-	cfg.iter = &fakeIter{}
 
 	var verifyKeys [][]byte
 
@@ -368,8 +362,10 @@ func Test_LoadVerifier(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		cfg := NewConfig("mlab-sandbox", tt.client)
 		cfg.iter = tt.iter
-		_, err := cfg.LoadVerifier(ctx, tt.client, "test2")
+
+		_, err := cfg.LoadVerifier(ctx, "test2")
 
 		if (err != nil) != tt.wantErr {
 			t.Fatalf("Got error: %v, but wantErr is %v", err, tt.wantErr)
@@ -379,8 +375,6 @@ func Test_LoadVerifier(t *testing.T) {
 
 func TestConfig_LoadPrometheus(t *testing.T) {
 	ctx := context.Background()
-
-	cfg := NewConfig("mlab-sandbox")
 
 	secretUser := "fake-user"
 	secretPass := "fake-pass"
@@ -415,7 +409,9 @@ func TestConfig_LoadPrometheus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := cfg.LoadPrometheus(ctx, tt.client, "fake-user", "fake-pass")
+			cfg := NewConfig("mlab-sandbox", tt.client)
+
+			got, err := cfg.LoadPrometheus(ctx, "fake-user", "fake-pass")
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Config.LoadPrometheus() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
This change is a cleanup to the `secrets.NewConfig` interface to encapsulate the `SecretClient` to simplify the interface of all `Load*` operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/194)
<!-- Reviewable:end -->
