### PR TITLE
Pass additional parameters to and through monitoring requests

### DIFF
--- a/cmd/monitoring-token/monitoring-token.go
+++ b/cmd/monitoring-token/monitoring-token.go
@@ -76,7 +76,8 @@ func main() {
 	rtx.Must(err, "Failed to sign claims")
 
 	// Add the token to the URL parameters in the request to the locate service.
-	params := url.Values{}
+	params, err := url.ParseQuery(locate.RawQuery)
+	rtx.Must(err, "failed to parse given query")
 	params.Set("access_token", token)
 	locate.RawQuery = params.Encode()
 	locate.Path = locate.Path + service

--- a/handler/monitoring.go
+++ b/handler/monitoring.go
@@ -38,6 +38,10 @@ func (c *Client) Monitoring(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Preserve other, given request parameters.
+	values := req.URL.Query()
+	values.Del("access_token")
+
 	// Get monitoring subject access tokens for the given machine.
 	machine := cl.Subject
 	token := c.getAccessToken(cl.Subject, static.SubjectMonitoring)
@@ -46,7 +50,7 @@ func (c *Client) Monitoring(rw http.ResponseWriter, req *http.Request) {
 	// v3 monitoring uses the service name as the subject, so this should be a noop.
 	m.Service = experiment
 	hostname := m.StringWithService()
-	urls := c.getURLs(ports, hostname, token, nil)
+	urls := c.getURLs(ports, hostname, token, values)
 	result.AccessToken = token
 	result.Target = &v2.Target{
 		// Monitoring results only include one target.


### PR DESCRIPTION
This change is part of support for end to end monitoring of the autonode deployments in sandbox and staging (and production). This change preserves request parameters to the Locate API when generating monitoring access tokens. This allows us to use the `early_exit=250` parameter on tests for monitoring, reducing overall resource consumption.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/198)
<!-- Reviewable:end -->
