### PR TITLE
Add logging for the Prometheus health handler

### DIFF
--- a/handler/prometheus.go
+++ b/handler/prometheus.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 	"time"
 
@@ -37,17 +38,20 @@ func (c *Client) Prometheus(rw http.ResponseWriter, req *http.Request) {
 	hostnames, err := c.query(req.Context(), e2eQuery, e2eLabel, e2eFunction)
 	if err != nil {
 		rw.WriteHeader(http.StatusInternalServerError)
+		log.Printf("Error querying Prometheus for %s metric: %v", e2eQuery, err)
 		return
 	}
 
 	machines, err := c.query(req.Context(), gmxQuery, gmxLabel, gmxFunction)
 	if err != nil {
+		log.Printf("Error querying Prometheus for %s metric: %v", gmxQuery, err)
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	err = c.UpdatePrometheus(hostnames, machines)
 	if err != nil {
+		log.Printf("Error updating internal Prometheus state: %v", err)
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
There are errors (i.e., response code = 500) in the requests from the [Cloud Scheduler job](https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_scheduler_job%22%20AND%20resource.labels.job_id%3D%22prometheus%22%20AND%20resource.labels.location%3D%22us-central1%22;cursorTimestamp=2024-10-31T16:32:02.375967863Z;startTime=2024-10-31T16:11:32.385Z;endTime=2024-10-31T18:11:32.385774Z?project=mlab-ns) to update the Locate's internal Prometheus state. However, because we don't have logging for request errors, we don't know what's causing them. This PR adds logging for such cases.
 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/199)
<!-- Reviewable:end -->
