### PR TITLE
Always pick nodes when org filter is specified

### DIFF
--- a/heartbeat/location.go
+++ b/heartbeat/location.go
@@ -285,8 +285,8 @@ func pickTargets(service string, sites []site) *TargetInfo {
 
 func alwaysPick(opts *NearestOptions) bool {
 	// Sites do not need further filtering if the query is already requesting
-	// only virtual machines or a specific set of sites.
-	return opts.Type == "virtual" || len(opts.Sites) > 0
+	// only virtual machines or a specific set of sites or a specific org.
+	return opts.Type == "virtual" || len(opts.Sites) > 0 || opts.Org != ""
 }
 
 // pickWithProbability returns true if a pseudo-random number in the interval


### PR DESCRIPTION
This change adds an additional condition to the `alwaysPick` expression that always picks when the "Org" filter is specified.

This is necessary because some autonode deployments are deployed at less than probability 1, with a small enough set of sites that Locate results can return 500 errors.