### PR TITLE
Use correct machine hostname for Prometheus query

### DIFF
--- a/handler/prometheus.go
+++ b/handler/prometheus.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/m-lab/go/host"
 	"github.com/m-lab/locate/static"
 	prom "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
@@ -47,9 +48,16 @@ func (c *Client) Prometheus(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(http.StatusOK)
 }
 
-// UpdatePrometheusForMachine updates the Prometheus signals for a single machine.
-func (c *Client) UpdatePrometheusForMachine(ctx context.Context, machine string) error {
-	err := c.updatePrometheus(ctx, fmt.Sprintf("machine=%s", machine))
+// UpdatePrometheusForMachine updates the Prometheus signals for a single machine hostname.
+func (c *Client) UpdatePrometheusForMachine(ctx context.Context, hostname string) error {
+	name, err := host.Parse(hostname)
+	if err != nil {
+		log.Printf("Error parsing hostname %s", hostname)
+		return err
+	}
+
+	machine := name.String()
+	err = c.updatePrometheus(ctx, fmt.Sprintf("machine=%s", machine))
 	if err != nil {
 		log.Printf("Error updating Prometheus signals for machine %s", machine)
 	}

--- a/handler/prometheus_test.go
+++ b/handler/prometheus_test.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -277,8 +276,6 @@ type fakePromClient struct {
 }
 
 func (p *fakePromClient) Query(ctx context.Context, query string, ts time.Time, opts ...prom.Option) (model.Value, prom.Warnings, error) {
-	fmt.Println(query)
-	fmt.Println(p.queryErr)
 	if query == p.queryErr {
 		return nil, prom.Warnings{}, errFakeQuery
 	}


### PR DESCRIPTION
This PR fixes the machine hostname used to query Prometheus for a single machine. Before, it was only passing in the "mlabN" part. Now, it's passing in the full name, which is needed to filter the metrics ([example](https://prometheus.mlab-oti.measurementlab.net/graph?g0.expr=gmx_machine_maintenance%7Bmachine%3D%22mlab1-atl04.mlab-oti.measurement-lab.org%22%7D&g0.tab=1&g0.display_mode=lines&g0.show_exemplars=0&g0.range_input=1h)).

Note: I'm not sure what is happening with Coveralls. That file was not modified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/204)
<!-- Reviewable:end -->
