### PR TITLE
Pass in hostname to Prometheus single instance update

### DIFF
--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -76,7 +76,7 @@ func (c *Client) handleHeartbeats(ws conn) error {
 				}
 
 				// Update Prometheus signals every time a Registration message is received.
-				c.promRegistration(context.Background(), hbm.Registration.Hostname)
+				c.UpdatePrometheusForMachine(context.Background(), hbm.Registration.Hostname)
 			case hbm.Health != nil:
 				if err := c.UpdateHealth(hostname, *hbm.Health); err != nil {
 					closeConnection(experiment, err)
@@ -85,14 +85,6 @@ func (c *Client) handleHeartbeats(ws conn) error {
 			}
 		}
 	}
-}
-
-func (c *Client) promRegistration(ctx context.Context, host string) error {
-	if err := c.UpdatePrometheusForMachine(ctx, host); err != nil {
-		log.Printf("Failed to update Prometheus after Registration: %v", err)
-		return err
-	}
-	return nil
 }
 
 // setReadDeadline sets/resets the read deadline for the connection.

--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -76,7 +76,7 @@ func (c *Client) handleHeartbeats(ws conn) error {
 				}
 
 				// Update Prometheus signals every time a Registration message is received.
-				c.UpdatePrometheusForMachine(context.Background(), hbm.Registration.Machine)
+				c.UpdatePrometheusForMachine(context.Background(), hbm.Registration.Hostname)
 			case hbm.Health != nil:
 				if err := c.UpdateHealth(hostname, *hbm.Health); err != nil {
 					closeConnection(experiment, err)

--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -76,7 +76,7 @@ func (c *Client) handleHeartbeats(ws conn) error {
 				}
 
 				// Update Prometheus signals every time a Registration message is received.
-				c.UpdatePrometheusForMachine(context.Background(), hbm.Registration.Hostname)
+				c.promRegistration(context.Background(), hbm.Registration.Hostname)
 			case hbm.Health != nil:
 				if err := c.UpdateHealth(hostname, *hbm.Health); err != nil {
 					closeConnection(experiment, err)
@@ -85,6 +85,14 @@ func (c *Client) handleHeartbeats(ws conn) error {
 			}
 		}
 	}
+}
+
+func (c *Client) promRegistration(ctx context.Context, host string) error {
+	if err := c.UpdatePrometheusForMachine(ctx, host); err != nil {
+		log.Printf("Failed to update Prometheus after Registration: %v", err)
+		return err
+	}
+	return nil
 }
 
 // setReadDeadline sets/resets the read deadline for the connection.

--- a/handler/heartbeat_test.go
+++ b/handler/heartbeat_test.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"github.com/m-lab/locate/heartbeat"
 	"github.com/m-lab/locate/heartbeat/heartbeattest"
 	prom "github.com/prometheus/client_golang/api/prometheus/v1"
-	"github.com/prometheus/common/model"
 )
 
 func TestClient_Heartbeat_Error(t *testing.T) {
@@ -64,46 +62,6 @@ func TestClient_handleHeartbeats(t *testing.T) {
 			err := c.handleHeartbeats(tt.ws)
 			if !errors.Is(err, wantErr) {
 				t.Errorf("Client.handleHeartbeats() error = %v, wantErr %v", err, wantErr)
-			}
-		})
-	}
-}
-
-func TestClient_promRegistration(t *testing.T) {
-	tests := []struct {
-		name    string
-		prom    *fakePromClient
-		host    string
-		wantErr bool
-	}{
-		{
-			name: "success",
-			prom: &fakePromClient{
-				queryResult: model.Vector{},
-			},
-			host:    testdata.FakeHostname,
-			wantErr: false,
-		},
-		{
-			name: "error",
-			prom: &fakePromClient{
-				queryResult: model.Vector{},
-			},
-			host:    "invalid-hostname",
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			locator := heartbeat.NewServerLocator(&heartbeattest.FakeStatusTracker{})
-			locator.StopImport()
-
-			c := &Client{
-				LocatorV2:        locator,
-				PrometheusClient: tt.prom,
-			}
-			if err := c.promRegistration(context.Background(), tt.host); (err != nil) != tt.wantErr {
-				t.Errorf("Client.promRegistration() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
This PR fixes the parameter for the single instance Prometheus update to be the Hostname.

This fixes the error: `Error parsing hostname mlab2`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/205)
<!-- Reviewable:end -->
