### PR TITLE
Add surrounding quotes to machine label name

### DIFF
--- a/handler/prometheus.go
+++ b/handler/prometheus.go
@@ -57,7 +57,7 @@ func (c *Client) UpdatePrometheusForMachine(ctx context.Context, hostname string
 	}
 
 	machine := name.String()
-	err = c.updatePrometheus(ctx, fmt.Sprintf("machine=%s", machine))
+	err = c.updatePrometheus(ctx, fmt.Sprintf("machine=\"%s\"", machine))
 	if err != nil {
 		log.Printf("Error updating Prometheus signals for machine %s", machine)
 	}

--- a/handler/prometheus.go
+++ b/handler/prometheus.go
@@ -57,7 +57,7 @@ func (c *Client) UpdatePrometheusForMachine(ctx context.Context, hostname string
 	}
 
 	machine := name.String()
-	err = c.updatePrometheus(ctx, fmt.Sprintf("machine=\"%s\"", machine))
+	err = c.updatePrometheus(ctx, fmt.Sprintf("machine=%q", machine))
 	if err != nil {
 		log.Printf("Error updating Prometheus signals for machine %s", machine)
 	}

--- a/handler/prometheus_test.go
+++ b/handler/prometheus_test.go
@@ -106,7 +106,7 @@ func TestClient_UpdatePrometheusForMachine(t *testing.T) {
 			name:     "prom-error",
 			hostname: hostname.StringAll(),
 			prom: &fakePromClient{
-				queryErr:    formatQuery(e2eQuery, "machine="+hostname.String()),
+				queryErr:    formatQuery(e2eQuery, "machine=\""+hostname.String()+"\""),
 				queryResult: model.Vector{},
 			},
 			tracker: &heartbeattest.FakeStatusTracker{},

--- a/handler/prometheus_test.go
+++ b/handler/prometheus_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -106,7 +107,7 @@ func TestClient_UpdatePrometheusForMachine(t *testing.T) {
 			name:     "prom-error",
 			hostname: hostname.StringAll(),
 			prom: &fakePromClient{
-				queryErr:    formatQuery(e2eQuery, "machine=\""+hostname.String()+"\""),
+				queryErr:    formatQuery(e2eQuery, fmt.Sprintf("machine=%q", hostname.String())),
 				queryResult: model.Vector{},
 			},
 			tracker: &heartbeattest.FakeStatusTracker{},


### PR DESCRIPTION
Apologies, I thought this was fully fixed but I see it's not. Prometheus label values take surrounding quotes (e.g., script_success{machine="mlab1-atl04.mlab-oti.measurement-lab.org"}. This PR adds them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/207)
<!-- Reviewable:end -->
