### PR TITLE
Adds new siteinfo package

### DIFF
--- a/siteinfo/siteinfo.go
+++ b/siteinfo/siteinfo.go
@@ -1,0 +1,44 @@
+package siteinfo
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/m-lab/go/host"
+	v2 "github.com/m-lab/locate/api/v2"
+)
+
+func Machines(msgs map[string]v2.HeartbeatMessage, v url.Values) (map[string]v2.HeartbeatMessage, error) {
+	machines := make(map[string]v2.HeartbeatMessage)
+
+	org := v.Get("org")
+	exp := v.Get("exp")
+
+	if org != "" || exp != "" {
+		for k, v := range msgs {
+			parts, err := host.Parse(k)
+			if err != nil {
+				returnError := fmt.Errorf("failed to parse hostname: %s", k)
+				return nil, returnError
+			}
+			if org != "" && exp == "" {
+				if org == parts.Org {
+					machines[k] = v
+				}
+			} else if org == "" && exp != "" {
+				if exp == parts.Service {
+					machines[k] = v
+				}
+			} else {
+				if org == parts.Org && exp == parts.Service {
+					machines[k] = v
+				}
+			}
+		}
+	} else {
+		machines = msgs
+	}
+
+	return machines, nil
+
+}

--- a/siteinfo/siteinfo.go
+++ b/siteinfo/siteinfo.go
@@ -8,6 +8,9 @@ import (
 	v2 "github.com/m-lab/locate/api/v2"
 )
 
+// Machines returns a map of machines that Locate knows about. The map values
+// are a combination of a machine's heartbeat registration information and
+// health informatiom from both heartbeat and Prometheus.
 func Machines(msgs map[string]v2.HeartbeatMessage, v url.Values) (map[string]v2.HeartbeatMessage, error) {
 	machines := make(map[string]v2.HeartbeatMessage)
 

--- a/siteinfo/siteinfo_test.go
+++ b/siteinfo/siteinfo_test.go
@@ -117,17 +117,17 @@ func TestMachines(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name: "success-return-all-records",
+			name:      "success-return-all-records",
+			instances: testInstances,
 			expectedKeys: []string{
 				"msak-chs9999-ab285f12.mlab.sandbox.measurement-lab.org",
 				"ndt-dfw8888-73a354f1.testorg.sandbox.measurement-lab.org",
 				"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
 			},
-			instances: testInstances,
-			wantErr:   false,
 		},
 		{
-			name: "success-return-mlab-records",
+			name:      "success-return-mlab-records",
+			instances: testInstances,
 			params: url.Values{
 				"org": {
 					"mlab",
@@ -137,11 +137,10 @@ func TestMachines(t *testing.T) {
 				"msak-chs9999-ab285f12.mlab.sandbox.measurement-lab.org",
 				"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
 			},
-			instances: testInstances,
-			wantErr:   false,
 		},
 		{
-			name: "success-return-ndt-records",
+			name:      "success-return-ndt-records",
+			instances: testInstances,
 			params: url.Values{
 				"exp": {
 					"ndt",
@@ -151,11 +150,10 @@ func TestMachines(t *testing.T) {
 				"ndt-dfw8888-73a354f1.testorg.sandbox.measurement-lab.org",
 				"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
 			},
-			instances: testInstances,
-			wantErr:   false,
 		},
 		{
-			name: "success-return-mlab-ndt-records",
+			name:      "success-return-mlab-ndt-records",
+			instances: testInstances,
 			params: url.Values{
 				"exp": {
 					"ndt",
@@ -167,18 +165,16 @@ func TestMachines(t *testing.T) {
 			expectedKeys: []string{
 				"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
 			},
-			instances: testInstances,
-			wantErr:   false,
 		},
 		{
 			name: "error-invalid-hostname",
+			instances: map[string]v2.HeartbeatMessage{
+				"invalid.hostname": {},
+			},
 			params: url.Values{
 				"org": {
 					"mlab",
 				},
-			},
-			instances: map[string]v2.HeartbeatMessage{
-				"invalid.hostname": {},
 			},
 			wantErr: true,
 		},

--- a/siteinfo/siteinfo_test.go
+++ b/siteinfo/siteinfo_test.go
@@ -1,0 +1,205 @@
+package siteinfo
+
+import (
+	"net/url"
+	"reflect"
+	"sort"
+	"testing"
+
+	v2 "github.com/m-lab/locate/api/v2"
+)
+
+var testInstances = map[string]v2.HeartbeatMessage{
+	"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org": {
+		Health: &v2.Health{
+			Score: 1,
+		},
+		Registration: &v2.Registration{
+			City:          "Omaha",
+			CountryCode:   "US",
+			ContinentCode: "NA",
+			Experiment:    "ndt",
+			Hostname:      "ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
+			Latitude:      41.3032,
+			Longitude:     -95.8941,
+			Machine:       "217f832a",
+			Metro:         "oma",
+			Project:       "mlab-sandbox",
+			Probability:   0.1,
+			Site:          "oma7777",
+			Type:          "unknown",
+			Uplink:        "unknown",
+			Services: map[string][]string{
+				"ndt/ndt7": {
+					"ws:///ndt/v7/download",
+					"ws:///ndt/v7/upload",
+					"wss:///ndt/v7/download",
+					"wss:///ndt/v7/upload",
+				},
+			},
+		},
+		Prometheus: &v2.Prometheus{
+			Health: true,
+		},
+	},
+	"ndt-dfw8888-73a354f1.testorg.sandbox.measurement-lab.org": {
+		Health: &v2.Health{
+			Score: 1,
+		},
+		Registration: &v2.Registration{
+			City:          "Dallas",
+			CountryCode:   "US",
+			ContinentCode: "NA",
+			Experiment:    "ndt",
+			Hostname:      "ndt-dfw8888-73a354f1.testorg.sandbox.measurement-lab.org",
+			Latitude:      32.8969,
+			Longitude:     -97.0381,
+			Machine:       "73a354f1",
+			Metro:         "dfw",
+			Project:       "mlab-sandbox",
+			Probability:   0.1,
+			Site:          "dfw8888",
+			Type:          "unknown",
+			Uplink:        "unknown",
+			Services: map[string][]string{
+				"ndt/ndt7": {
+					"ws:///ndt/v7/download",
+					"ws:///ndt/v7/upload",
+					"wss:///ndt/v7/download",
+					"wss:///ndt/v7/upload",
+				},
+			},
+		},
+		Prometheus: &v2.Prometheus{
+			Health: true,
+		},
+	},
+	"msak-chs9999-ab285f12.mlab.sandbox.measurement-lab.org": {
+		Health: &v2.Health{
+			Score: 1,
+		},
+		Registration: &v2.Registration{
+			City:          "Charleston",
+			CountryCode:   "US",
+			ContinentCode: "NA",
+			Experiment:    "msak",
+			Hostname:      "msak-chs9999-ab285f12.mlab.sandbox.measurement-lab.org",
+			Latitude:      32.8986,
+			Longitude:     -80.0405,
+			Machine:       "ab285f12",
+			Metro:         "chs",
+			Project:       "mlab-sandbox",
+			Probability:   0.5,
+			Site:          "chs9999",
+			Type:          "unknown",
+			Uplink:        "unknown",
+			Services: map[string][]string{
+				"ndt/ndt7": {
+					"ws:///ndt/v7/download",
+					"ws:///ndt/v7/upload",
+					"wss:///ndt/v7/download",
+					"wss:///ndt/v7/upload",
+				},
+			},
+		},
+		Prometheus: &v2.Prometheus{
+			Health: false,
+		},
+	},
+}
+
+func TestMachines(t *testing.T) {
+	tests := []struct {
+		name         string
+		params       url.Values
+		expectedKeys []string
+		instances    map[string]v2.HeartbeatMessage
+		wantErr      bool
+	}{
+		{
+			name: "success-return-all-records",
+			expectedKeys: []string{
+				"msak-chs9999-ab285f12.mlab.sandbox.measurement-lab.org",
+				"ndt-dfw8888-73a354f1.testorg.sandbox.measurement-lab.org",
+				"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
+			},
+			instances: testInstances,
+			wantErr:   false,
+		},
+		{
+			name: "success-return-mlab-records",
+			params: url.Values{
+				"org": {
+					"mlab",
+				},
+			},
+			expectedKeys: []string{
+				"msak-chs9999-ab285f12.mlab.sandbox.measurement-lab.org",
+				"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
+			},
+			instances: testInstances,
+			wantErr:   false,
+		},
+		{
+			name: "success-return-ndt-records",
+			params: url.Values{
+				"exp": {
+					"ndt",
+				},
+			},
+			expectedKeys: []string{
+				"ndt-dfw8888-73a354f1.testorg.sandbox.measurement-lab.org",
+				"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
+			},
+			instances: testInstances,
+			wantErr:   false,
+		},
+		{
+			name: "success-return-mlab-ndt-records",
+			params: url.Values{
+				"exp": {
+					"ndt",
+				},
+				"org": {
+					"mlab",
+				},
+			},
+			expectedKeys: []string{
+				"ndt-oma7777-217f832a.mlab.sandbox.measurement-lab.org",
+			},
+			instances: testInstances,
+			wantErr:   false,
+		},
+		{
+			name: "error-invalid-hostname",
+			params: url.Values{
+				"org": {
+					"mlab",
+				},
+			},
+			instances: map[string]v2.HeartbeatMessage{
+				"invalid.hostname": {},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		var resultKeys []string
+
+		result, err := Machines(test.instances, test.params)
+		if (err != nil) != test.wantErr {
+			t.Errorf("Machines() error = %v, wantErr %v", err, test.wantErr)
+		}
+
+		for k := range result {
+			resultKeys = append(resultKeys, k)
+		}
+
+		sort.Strings(resultKeys)
+
+		if !reflect.DeepEqual(test.expectedKeys, resultKeys) {
+			t.Errorf("Machines() wanted = %v, got %v", test.expectedKeys, resultKeys)
+		}
+	}
+}


### PR DESCRIPTION
The siteinfo package will generate various formats, which will all be variations of heartbeat registration information. It is intended to at least partially handle what the siteinfo repository does not provide. Today, siteinfo has no information about autojoin machines, and in the not-distant future siteinfo will likely no longer track VMs either. On the other hand, Locate knows about _all_ machines on the platform.

As a start, this new package only implements a singe "Machines" format, which is nothing more than a dump of all v2.HeartbeatMessages that Locate knows about. Eventually it can support formats like "Geo", "Sites", etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/208)
<!-- Reviewable:end -->
