### PR TITLE
Add new handler for the recently added siteinfo package

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -229,6 +229,11 @@ func (c *Client) Ready(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// Registrations returns an array of all machine registrations known to Locate.
+func (c *Client) Registrations(rw http.ResponseWriter, req *http.Request) {
+	writeResult(rw, http.StatusOK, c.LocatorV2.Instances())
+}
+
 // checkClientLocation looks up the client location and copies the location
 // headers to the response writer.
 func (c *Client) checkClientLocation(rw http.ResponseWriter, req *http.Request) (*clientgeo.Location, error) {

--- a/heartbeat/heartbeattest/heartbeattest.go
+++ b/heartbeat/heartbeattest/heartbeattest.go
@@ -53,7 +53,8 @@ func (c *fakeErrorMemorystoreClient[V]) GetAll() (map[string]V, error) {
 
 // FakeStatusTracker provides a fake implementation of HeartbeatStatusTracker.
 type FakeStatusTracker struct {
-	Err error
+	Err           error
+	FakeInstances map[string]v2.HeartbeatMessage
 }
 
 // RegisterInstance returns the FakeStatusTracker's Err field.
@@ -73,6 +74,9 @@ func (t *FakeStatusTracker) UpdatePrometheus(hostnames, machines map[string]bool
 
 // Instances returns nil.
 func (t *FakeStatusTracker) Instances() map[string]v2.HeartbeatMessage {
+	if t.FakeInstances != nil {
+		return t.FakeInstances
+	}
 	return nil
 }
 

--- a/locate.go
+++ b/locate.go
@@ -205,6 +205,9 @@ func main() {
 	mux.HandleFunc("/v2/live", c.Live)
 	mux.HandleFunc("/v2/ready", c.Ready)
 
+	// Return list of all heartbeat registrations
+	mux.HandleFunc("/v2/siteinfo/registrations", c.Registrations)
+
 	srv := &http.Server{
 		Addr:    ":" + listenPort,
 		Handler: mux,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -169,6 +169,19 @@ paths:
       tags:
         - platform
 
+  "/v2/siteinfo/registrations":
+    get:
+      description: |-
+        Returns an array of all heartbeat registrations
+      operationId: "v2-siteinfo-registrations"
+      produces:
+      - "application/json"
+      responses:
+        '200':
+          description: OK.
+      tags:
+        - siteinfo
+
 definitions:
   # Define the query reply without being specific about the structure.
   ErrorResult:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -172,13 +172,15 @@ paths:
   "/v2/siteinfo/registrations":
     get:
       description: |-
-        Returns an array of all heartbeat registrations
+        Returns heartbeat registration information in various formats.
       operationId: "v2-siteinfo-registrations"
       produces:
       - "application/json"
       responses:
         '200':
           description: OK.
+        '500':
+          description: Error.
       tags:
         - siteinfo
 


### PR DESCRIPTION
A new path specification of /v2/siteinfo/registrations was added. Requests to this endpoint will be handled by the siteinfo package. The endpoint supports 3 query parameters:

* format - defines the format of the returned JSON
* org - limits results to only records for the given organization (e.g., mlab, rnp, etc.)
* exp - limits results to only records for the given experiment (e.g., ndt, msak, etc.)

It seems to working as intended: https://mlab-sandbox.appspot.com/v2/siteinfo/registrations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/209)
<!-- Reviewable:end -->
