### PR TITLE
Implement rate limiting based on IP+UA

### DIFF
--- a/cloudbuild/app.yaml.mlab-ns.template
+++ b/cloudbuild/app.yaml.mlab-ns.template
@@ -37,5 +37,6 @@ env_variables:
   LOCATOR_MAXMIND: true
   MAXMIND_URL: gs://downloader-{{PLATFORM_PROJECT}}/Maxmind/current/GeoLite2-City.tar.gz
   REDIS_ADDRESS: {{REDIS_ADDRESS}}
+  RATE_LIMIT_REDIS_ADDRESS: {{RATE_LIMIT_REDIS_ADDRESS}}
   PROMETHEUSX_LISTEN_ADDRESS: ':9090' # Must match one of the forwarded_ports above.
   PROMETHEUS_URL: 'https://prometheus-basicauth.{{PLATFORM_PROJECT}}.measurementlab.net/'

--- a/cloudbuild/app.yaml.template
+++ b/cloudbuild/app.yaml.template
@@ -36,5 +36,6 @@ env_variables:
   LOCATOR_MAXMIND: true
   MAXMIND_URL: gs://downloader-{{PLATFORM_PROJECT}}/Maxmind/current/GeoLite2-City.tar.gz
   REDIS_ADDRESS: {{REDIS_ADDRESS}}
+  RATE_LIMIT_REDIS_ADDRESS: {{RATE_LIMIT_REDIS_ADDRESS}}
   PROMETHEUSX_LISTEN_ADDRESS: ':9090' # Must match one of the forwarded_ports above.
   PROMETHEUS_URL: 'https://prometheus-basicauth.{{PLATFORM_PROJECT}}.measurementlab.net/'

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -2,55 +2,55 @@ timeout: 3600s
 
 options:
   env:
-    - PROJECT_ID=$PROJECT_ID
-    - WORKSPACE_LINK=/go/src/github.com/m-lab/locate
+  - PROJECT_ID=$PROJECT_ID
+  - WORKSPACE_LINK=/go/src/github.com/m-lab/locate
 
 steps:
-  # Run unit tests for environment.
-  - name: gcr.io/$PROJECT_ID/golang-cbif:1.20
-    env:
-      - GONOPROXY=github.com/m-lab/go/*
-    args:
-      - go version
-      - go get -v -t ./...
-      - go vet ./...
-      - go test ./... -race
-      - go test -v ./...
+# Run unit tests for environment.
+- name: gcr.io/$PROJECT_ID/golang-cbif:1.20
+  env:
+  - GONOPROXY=github.com/m-lab/go/*
+  args:
+  - go version
+  - go get -v -t ./...
+  - go vet ./...
+  - go test ./... -race
+  - go test -v ./...
 
-  # Deployment of APIs in sandbox & staging.
-  - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
-    env:
-      # Use cbif condition: only run these steps in one of these projects.
-      - PROJECT_IN=mlab-sandbox,mlab-staging
-    args:
-      - cp cloudbuild/app.yaml.template app.yaml
-      - >
-        sed -i
-        -e 's/{{PROJECT}}/$PROJECT_ID/g'
-        -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
-        -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
-        -e 's/{{RATE_LIMIT_REDIS_ADDRESS}}/$_RATE_LIMIT_REDIS_ADDRESS/'
-        app.yaml
-      - gcloud --project $PROJECT_ID app deploy --promote app.yaml
-      # After deploying the new service, deploy the openapi spec.
-      - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
-      - gcloud endpoints services deploy openapi.yaml
+# Deployment of APIs in sandbox & staging.
+- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
+  env:
+  # Use cbif condition: only run these steps in one of these projects.
+  - PROJECT_IN=mlab-sandbox,mlab-staging
+  args:
+  - cp cloudbuild/app.yaml.template app.yaml
+  - >
+    sed -i
+    -e 's/{{PROJECT}}/$PROJECT_ID/g'
+    -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
+    -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
+    -e 's/{{RATE_LIMIT_REDIS_ADDRESS}}/$_RATE_LIMIT_REDIS_ADDRESS/'
+    app.yaml
+  - gcloud --project $PROJECT_ID app deploy --promote app.yaml
+  # After deploying the new service, deploy the openapi spec.
+  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
+  - gcloud endpoints services deploy openapi.yaml
 
-  # Deployment of APIs in mlab-ns.
-  - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
-    env:
-      # Use cbif condition: only run these steps in this project.
-      - PROJECT_IN=mlab-ns
-    args:
-      - cp cloudbuild/app.yaml.mlab-ns.template app.yaml
-      - >
-        sed -i
-        -e 's/{{PROJECT}}/$PROJECT_ID/g'
-        -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
-        -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
-        -e 's/{{RATE_LIMIT_REDIS_ADDRESS}}/$_RATE_LIMIT_REDIS_ADDRESS/'
-        app.yaml
-      - gcloud --project $PROJECT_ID app deploy --promote app.yaml
-      # After deploying the new service, deploy the openapi spec.
-      - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/Production/' openapi.yaml
-      - gcloud endpoints services deploy openapi.yaml
+# Deployment of APIs in mlab-ns.
+- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
+  env:
+  # Use cbif condition: only run these steps in this project.
+  - PROJECT_IN=mlab-ns
+  args:
+  - cp cloudbuild/app.yaml.mlab-ns.template app.yaml
+  - >
+    sed -i
+    -e 's/{{PROJECT}}/$PROJECT_ID/g'
+    -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
+    -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
+    -e 's/{{RATE_LIMIT_REDIS_ADDRESS}}/$_RATE_LIMIT_REDIS_ADDRESS/'
+    app.yaml
+  - gcloud --project $PROJECT_ID app deploy --promote app.yaml
+  # After deploying the new service, deploy the openapi spec.
+  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/Production/' openapi.yaml
+  - gcloud endpoints services deploy openapi.yaml

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -2,53 +2,55 @@ timeout: 3600s
 
 options:
   env:
-  - PROJECT_ID=$PROJECT_ID
-  - WORKSPACE_LINK=/go/src/github.com/m-lab/locate
+    - PROJECT_ID=$PROJECT_ID
+    - WORKSPACE_LINK=/go/src/github.com/m-lab/locate
 
 steps:
-# Run unit tests for environment.
-- name: gcr.io/$PROJECT_ID/golang-cbif:1.20
-  env:
-  - GONOPROXY=github.com/m-lab/go/*
-  args:
-  - go version
-  - go get -v -t ./...
-  - go vet ./...
-  - go test ./... -race
-  - go test -v ./...
+  # Run unit tests for environment.
+  - name: gcr.io/$PROJECT_ID/golang-cbif:1.20
+    env:
+      - GONOPROXY=github.com/m-lab/go/*
+    args:
+      - go version
+      - go get -v -t ./...
+      - go vet ./...
+      - go test ./... -race
+      - go test -v ./...
 
-# Deployment of APIs in sandbox & staging.
-- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
-  env:
-  # Use cbif condition: only run these steps in one of these projects.
-  - PROJECT_IN=mlab-sandbox,mlab-staging
-  args:
-  - cp cloudbuild/app.yaml.template app.yaml
-  - >
-    sed -i
-    -e 's/{{PROJECT}}/$PROJECT_ID/g'
-    -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
-    -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
-    app.yaml
-  - gcloud --project $PROJECT_ID app deploy --promote app.yaml
-  # After deploying the new service, deploy the openapi spec.
-  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
-  - gcloud endpoints services deploy openapi.yaml
+  # Deployment of APIs in sandbox & staging.
+  - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
+    env:
+      # Use cbif condition: only run these steps in one of these projects.
+      - PROJECT_IN=mlab-sandbox,mlab-staging
+    args:
+      - cp cloudbuild/app.yaml.template app.yaml
+      - >
+        sed -i
+        -e 's/{{PROJECT}}/$PROJECT_ID/g'
+        -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
+        -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
+        -e 's/{{RATE_LIMIT_REDIS_ADDRESS}}/$_RATE_LIMIT_REDIS_ADDRESS/'
+        app.yaml
+      - gcloud --project $PROJECT_ID app deploy --promote app.yaml
+      # After deploying the new service, deploy the openapi spec.
+      - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
+      - gcloud endpoints services deploy openapi.yaml
 
-# Deployment of APIs in mlab-ns.
-- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
-  env:
-  # Use cbif condition: only run these steps in this project.
-  - PROJECT_IN=mlab-ns
-  args:
-  - cp cloudbuild/app.yaml.mlab-ns.template app.yaml
-  - >
-    sed -i
-    -e 's/{{PROJECT}}/$PROJECT_ID/g'
-    -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
-    -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
-    app.yaml
-  - gcloud --project $PROJECT_ID app deploy --promote app.yaml
-  # After deploying the new service, deploy the openapi spec.
-  - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/Production/' openapi.yaml
-  - gcloud endpoints services deploy openapi.yaml
+  # Deployment of APIs in mlab-ns.
+  - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif:1.1
+    env:
+      # Use cbif condition: only run these steps in this project.
+      - PROJECT_IN=mlab-ns
+    args:
+      - cp cloudbuild/app.yaml.mlab-ns.template app.yaml
+      - >
+        sed -i
+        -e 's/{{PROJECT}}/$PROJECT_ID/g'
+        -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/'
+        -e 's/{{REDIS_ADDRESS}}/$_REDIS_ADDRESS/'
+        -e 's/{{RATE_LIMIT_REDIS_ADDRESS}}/$_RATE_LIMIT_REDIS_ADDRESS/'
+        app.yaml
+      - gcloud --project $PROJECT_ID app deploy --promote app.yaml
+      # After deploying the new service, deploy the openapi spec.
+      - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{DEPLOYMENT}}/Production/' openapi.yaml
+      - gcloud endpoints services deploy openapi.yaml

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/compute/metadata v0.2.3
 	cloud.google.com/go/secretmanager v1.11.2
+	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/apex/log v1.9.0
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/go-test/deep v1.0.8
@@ -33,12 +34,14 @@ require (
 )
 
 require (
+	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/evanphx/json-patch v4.9.0+incompatible // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	golang.org/x/sync v0.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231016165738-49dd2c1f3d0b // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,10 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 h1:uvdUDbHQHO85qeSydJtItA4T55Pw6BtAejd0APRJOCE=
+github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
+github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j82Yjf3KFv7ApYzUI=
+github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
 github.com/apex/log v1.9.0 h1:FHtw/xuaM8AgmvDDTI9fiwoAL25Sq2cxojnZICUU8l0=
 github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA=
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
@@ -360,6 +364,8 @@ github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKw
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -177,6 +177,8 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 				metrics.RequestsTotal.WithLabelValues("nearest", "rate limit",
 					http.StatusText(result.Error.Status)).Inc()
 				// For now, we only log the rate limit exceeded message.
+				// TODO: Actually block the request and return an appropriate HTTP error
+				// code and message.
 				log.Printf("Rate limit exceeded for IP %s and UA %s", ip, ua)
 			}
 		} else {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -172,7 +172,7 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 				// Log error but don't block request (fail open).
 				log.Printf("Rate limiter error: %v", err)
 			} else if limited {
-				result.Error = v2.NewError("client", "Rate limit exceeded", http.StatusTooManyRequests)
+				result.Error = v2.NewError("client", tooManyRequests, http.StatusTooManyRequests)
 				writeResult(rw, result.Error.Status, &result)
 				metrics.RequestsTotal.WithLabelValues("nearest", "rate limit",
 					http.StatusText(result.Error.Status)).Inc()

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -172,8 +172,6 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 				// Log error but don't block request (fail open).
 				log.Printf("Rate limiter error: %v", err)
 			} else if limited {
-				result.Error = v2.NewError("client", tooManyRequests, http.StatusTooManyRequests)
-				writeResult(rw, result.Error.Status, &result)
 				metrics.RequestsTotal.WithLabelValues("nearest", "rate limit",
 					http.StatusText(result.Error.Status)).Inc()
 				// For now, we only log the rate limit exceeded message.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -172,6 +172,7 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 			limited, err := c.ipLimiter.IsLimited(ip, ua)
 			if err != nil {
 				// Log error but don't block request (fail open).
+				// TODO: Add tests for this path.
 				log.Printf("Rate limiter error: %v", err)
 			} else if limited {
 				metrics.RequestsTotal.WithLabelValues("nearest", "rate limit",

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -162,7 +162,9 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 		// be set by AppEngine.
 		ip := req.Header.Get("X-Forwarded-For")
 		ips := strings.Split(ip, ",")
-		ip = strings.TrimSpace(ips[0])
+		if len(ips) > 0 {
+			ip = strings.TrimSpace(ips[0])
+		}
 		if ip != "" {
 			// An empty UA is technically possible. In this case, the key will be
 			// "ip:" and the rate limiting will be based on the IP address only.

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -212,7 +212,7 @@ func TestClient_Nearest(t *testing.T) {
 			if tt.cl == nil {
 				tt.cl = clientgeo.NewAppEngineLocator()
 			}
-			c := NewClient(tt.project, tt.signer, tt.locator, tt.cl, prom.NewAPI(nil), tt.limits)
+			c := NewClient(tt.project, tt.signer, tt.locator, tt.cl, prom.NewAPI(nil), tt.limits, nil)
 
 			mux := http.NewServeMux()
 			mux.HandleFunc("/v2/nearest/", c.Nearest)
@@ -291,7 +291,7 @@ func TestClient_Ready(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewClient("foo", &fakeSigner{}, &fakeLocatorV2{StatusTracker: &heartbeattest.FakeStatusTracker{Err: tt.fakeErr}}, nil, nil, nil)
+			c := NewClient("foo", &fakeSigner{}, &fakeLocatorV2{StatusTracker: &heartbeattest.FakeStatusTracker{Err: tt.fakeErr}}, nil, nil, nil, nil)
 
 			mux := http.NewServeMux()
 			mux.HandleFunc("/ready/", c.Ready)
@@ -349,7 +349,7 @@ func TestClient_Registrations(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewClient("foo", &fakeSigner{}, &fakeLocatorV2{StatusTracker: fakeStatusTracker}, nil, nil, nil)
+			c := NewClient("foo", &fakeSigner{}, &fakeLocatorV2{StatusTracker: fakeStatusTracker}, nil, nil, nil, nil)
 
 			mux := http.NewServeMux()
 			mux.HandleFunc("/v2/siteinfo/registrations/", c.Registrations)

--- a/handler/heartbeat_test.go
+++ b/handler/heartbeat_test.go
@@ -70,7 +70,7 @@ func TestClient_handleHeartbeats(t *testing.T) {
 func fakeClient(t heartbeat.StatusTracker) *Client {
 	locatorv2 := fakeLocatorV2{StatusTracker: t}
 	return NewClient("mlab-sandbox", &fakeSigner{}, &locatorv2,
-		clientgeo.NewAppEngineLocator(), prom.NewAPI(nil), nil)
+		clientgeo.NewAppEngineLocator(), prom.NewAPI(nil), nil, nil)
 }
 
 type fakeConn struct {

--- a/handler/monitoring_test.go
+++ b/handler/monitoring_test.go
@@ -92,7 +92,7 @@ func TestClient_Monitoring(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := clientgeo.NewAppEngineLocator()
-			c := NewClient("mlab-sandbox", tt.signer, tt.locator, cl, prom.NewAPI(nil), nil)
+			c := NewClient("mlab-sandbox", tt.signer, tt.locator, cl, prom.NewAPI(nil), nil, nil)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/v2/platform/monitoring/"+tt.path, nil)
 			req = req.Clone(controller.SetClaim(req.Context(), tt.claim))

--- a/limits/ratelimiter.go
+++ b/limits/ratelimiter.go
@@ -10,9 +10,9 @@ import (
 
 // RateLimitConfig holds the configuration for IP+UA rate limiting
 type RateLimitConfig struct {
-	Interval  time.Duration `yaml:"interval"`
-	MaxEvents int           `yaml:"maxevents"`
-	KeyPrefix string        `yaml:"keyprefix"`
+	Interval  time.Duration
+	MaxEvents int
+	KeyPrefix string
 }
 
 // RateLimiter implements a distributed rate limiter using Redis ZSET

--- a/limits/ratelimiter.go
+++ b/limits/ratelimiter.go
@@ -1,0 +1,80 @@
+package limits
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+// RateLimitConfig holds the configuration for IP+UA rate limiting
+type RateLimitConfig struct {
+	Interval  time.Duration `yaml:"interval"`
+	MaxEvents int           `yaml:"maxevents"`
+	KeyPrefix string        `yaml:"keyprefix"`
+}
+
+// RateLimiter implements a distributed rate limiter using Redis ZSET
+type RateLimiter struct {
+	pool      *redis.Pool
+	interval  time.Duration
+	maxEvents int
+	keyPrefix string
+}
+
+// NewRateLimiter creates a new rate limiter
+func NewRateLimiter(pool *redis.Pool, config RateLimitConfig) *RateLimiter {
+	return &RateLimiter{
+		pool:      pool,
+		interval:  config.Interval,
+		maxEvents: config.MaxEvents,
+		keyPrefix: config.KeyPrefix,
+	}
+}
+
+// generateKey creates a Redis key from IP and User-Agent
+func (rl *RateLimiter) generateKey(ip, ua string) string {
+	return fmt.Sprintf("%s%s:%s", rl.keyPrefix, ip, ua)
+}
+
+// IsLimited checks if the given IP and User-Agent combination should be rate limited.
+func (rl *RateLimiter) IsLimited(ip, ua string) (bool, error) {
+	conn := rl.pool.Get()
+	defer conn.Close()
+
+	now := time.Now().UnixMicro()
+	windowStart := now - rl.interval.Microseconds()
+	redisKey := rl.generateKey(ip, ua)
+
+	// Send all commands in pipeline.
+	// ZREMRANGEBYSCORE removes all events before the window start.
+	conn.Send("ZREMRANGEBYSCORE", redisKey, "-inf", windowStart)
+	// ZADD adds the current event to the ZSET.
+	conn.Send("ZADD", redisKey, now, strconv.FormatInt(now, 10))
+	// EXPIRE sets the key to expire after the interval.
+	conn.Send("EXPIRE", redisKey, int64(rl.interval.Seconds()))
+	// ZCARD returns the number of events in the ZSET for the given key.
+	conn.Send("ZCARD", redisKey)
+
+	// Flush pipeline
+	if err := conn.Flush(); err != nil {
+		return false, fmt.Errorf("failed to flush pipeline: %w", err)
+	}
+
+	// Receive all replies
+	for i := 0; i < 3; i++ {
+		// Receive replies for ZREMRANGEBYSCORE, ZADD, and EXPIRE
+		if _, err := conn.Receive(); err != nil {
+			return false, fmt.Errorf("failed to receive reply %d: %w", i, err)
+		}
+	}
+
+	// Receive and process ZCARD reply
+	count, err := redis.Int64(conn.Receive())
+	if err != nil {
+		return false, fmt.Errorf("failed to receive count: %w", err)
+	}
+
+	return count > int64(rl.maxEvents), nil
+}

--- a/limits/ratelimiter.go
+++ b/limits/ratelimiter.go
@@ -45,7 +45,7 @@ func NewRateLimiter(pool *redis.Pool, config RateLimitConfig) *RateLimiter {
 
 // generateKey creates a Redis key from IP and User-Agent.
 func (rl *RateLimiter) generateKey(ip, ua string) string {
-	return fmt.Sprintf("%s%s:%s", rl.keyPrefix, ip, ua)
+	return fmt.Sprintf("%s:%s:%s", rl.keyPrefix, ip, ua)
 }
 
 // IsLimited checks if the given IP and User-Agent combination should be rate limited.

--- a/limits/ratelimiter.go
+++ b/limits/ratelimiter.go
@@ -8,10 +8,13 @@ import (
 	"github.com/gomodule/redigo/redis"
 )
 
-// RateLimitConfig holds the configuration for IP+UA rate limiting
+// RateLimitConfig holds the configuration for IP+UA rate limiting.
 type RateLimitConfig struct {
-	Interval  time.Duration
+	// Interval defines the duration of the sliding window.
+	Interval time.Duration
+	// MaxEvents defines the maximum number of events allowed in the interval.
 	MaxEvents int
+	// KeyPrefix is the prefix for Redis keys.
 	KeyPrefix string
 }
 
@@ -30,7 +33,7 @@ type RateLimiter struct {
 	keyPrefix string
 }
 
-// NewRateLimiter creates a new rate limiter
+// NewRateLimiter creates a new rate limiter.
 func NewRateLimiter(pool *redis.Pool, config RateLimitConfig) *RateLimiter {
 	return &RateLimiter{
 		pool:      pool,
@@ -40,7 +43,7 @@ func NewRateLimiter(pool *redis.Pool, config RateLimitConfig) *RateLimiter {
 	}
 }
 
-// generateKey creates a Redis key from IP and User-Agent
+// generateKey creates a Redis key from IP and User-Agent.
 func (rl *RateLimiter) generateKey(ip, ua string) string {
 	return fmt.Sprintf("%s%s:%s", rl.keyPrefix, ip, ua)
 }

--- a/limits/ratelimiter_bench_test.go
+++ b/limits/ratelimiter_bench_test.go
@@ -1,0 +1,141 @@
+package limits
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+)
+
+// getRedisMemory returns the current memory usage in bytes
+func getRedisMemory(pool *redis.Pool) (int64, error) {
+	conn := pool.Get()
+	defer conn.Close()
+
+	info, err := redis.String(conn.Do("INFO", "memory"))
+	if err != nil {
+		return 0, err
+	}
+
+	var used int64
+	for _, line := range strings.Split(info, "\r\n") {
+		if strings.HasPrefix(line, "used_memory:") {
+			fmt.Sscanf(line, "used_memory:%d", &used)
+			break
+		}
+	}
+	return used, nil
+}
+
+func BenchmarkRateLimiter_RealWorld(b *testing.B) {
+	pool := &redis.Pool{
+		MaxIdle:     3,
+		IdleTimeout: 240 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", "localhost:6379")
+		},
+	}
+
+	// Create rate limiter with 60 requests/hour limit
+	limiter := NewRateLimiter(pool, RateLimitConfig{
+		Interval:  time.Hour,
+		MaxEvents: 60,
+		KeyPrefix: "benchmark:",
+	})
+
+	// Clean up before and after benchmark
+	conn := pool.Get()
+	conn.Do("FLUSHDB")
+	conn.Close()
+
+	// defer func() {
+	// 	conn := pool.Get()
+	// 	defer conn.Close()
+	// 	conn.Do("FLUSHDB")
+	// }()
+
+	tests := []struct {
+		name     string
+		duration time.Duration
+		ipRange  int // Number of unique IPs
+		uaRange  int // Number of unique UAs
+	}{
+		{
+			name:     "SingleIPUA_Long",
+			duration: 5 * time.Second,
+			ipRange:  1,
+			uaRange:  1,
+		},
+		// {
+		// 	name:     "ManyIPs_OneUA",
+		// 	duration: 5 * time.Second,
+		// 	ipRange:  100000,
+		// 	uaRange:  1,
+		// },
+		// {
+		// 	name:     "OneIP_ManyUAs",
+		// 	duration: 5 * time.Second,
+		// 	ipRange:  1,
+		// 	uaRange:  100000,
+		// },
+		// {
+		// 	name:     "ManyIPs_ManyUAs",
+		// 	duration: 5 * time.Second,
+		// 	ipRange:  100,
+		// 	uaRange:  10000,
+		// },
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			// Get initial memory usage
+			memBefore, err := getRedisMemory(pool)
+			if err != nil {
+				b.Fatalf("Failed to get initial memory: %v", err)
+			}
+
+			// Run benchmark with custom timer
+			b.ResetTimer()
+			start := time.Now()
+			ops := 0
+			for time.Since(start) < tt.duration {
+				ip := fmt.Sprintf("%d", ops%tt.ipRange)
+				ua := fmt.Sprintf("%d", ops%tt.uaRange)
+
+				_, err := limiter.IsLimited(ip, ua)
+				if err != nil {
+					b.Fatalf("IsLimited failed: %v", err)
+				}
+				ops++
+			}
+			b.StopTimer()
+
+			// Get final memory usage.
+			memAfter, err := getRedisMemory(pool)
+			if err != nil {
+				b.Fatalf("Failed to get final memory: %v", err)
+			}
+
+			// Add custom metrics.
+			duration := time.Since(start)
+			opsPerSec := float64(ops) / duration.Seconds()
+			memoryUsed := memAfter - memBefore
+
+			b.ReportMetric(float64(memoryUsed), "memory_bytes")
+			b.ReportMetric(opsPerSec, "ops/sec")
+			b.ReportMetric(float64(memoryUsed)/float64(ops), "bytes/key")
+
+			b.Logf("Total operations: %d", ops)
+			b.Logf("Memory used: %.2f MB", float64(memoryUsed)/(1024*1024))
+			b.Logf("Memory per key: %.2f bytes", float64(memoryUsed)/float64(ops))
+			b.Logf("Operations/sec: %.2f", opsPerSec)
+		})
+
+		// Clean up between tests
+		conn := pool.Get()
+		//conn.Do("FLUSHDB")
+		conn.Close()
+	}
+}

--- a/limits/ratelimiter_bench_test.go
+++ b/limits/ratelimiter_bench_test.go
@@ -63,28 +63,24 @@ func BenchmarkRateLimiter_RealWorld(b *testing.B) {
 		uaRange  int // Number of unique UAs
 	}{
 		{
-			name:     "SingleIPUA_Long",
-			duration: 5 * time.Second,
-			ipRange:  1,
-			uaRange:  1,
+			name:    "SingleIPUA_Long",
+			ipRange: 1,
+			uaRange: 1,
 		},
 		{
-			name:     "ManyIPs_OneUA",
-			duration: 5 * time.Second,
-			ipRange:  100000,
-			uaRange:  1,
+			name:    "ManyIPs_OneUA",
+			ipRange: 100000,
+			uaRange: 1,
 		},
 		{
-			name:     "OneIP_ManyUAs",
-			duration: 5 * time.Second,
-			ipRange:  1,
-			uaRange:  100000,
+			name:    "OneIP_ManyUAs",
+			ipRange: 1,
+			uaRange: 100000,
 		},
 		{
-			name:     "ManyIPs_ManyUAs",
-			duration: 5 * time.Second,
-			ipRange:  100,
-			uaRange:  10000,
+			name:    "ManyIPs_ManyUAs",
+			ipRange: 100,
+			uaRange: 10000,
 		},
 	}
 

--- a/limits/ratelimiter_bench_test.go
+++ b/limits/ratelimiter_bench_test.go
@@ -50,11 +50,11 @@ func BenchmarkRateLimiter_RealWorld(b *testing.B) {
 	conn.Do("FLUSHDB")
 	conn.Close()
 
-	// defer func() {
-	// 	conn := pool.Get()
-	// 	defer conn.Close()
-	// 	conn.Do("FLUSHDB")
-	// }()
+	defer func() {
+		conn := pool.Get()
+		defer conn.Close()
+		conn.Do("FLUSHDB")
+	}()
 
 	tests := []struct {
 		name     string
@@ -68,24 +68,24 @@ func BenchmarkRateLimiter_RealWorld(b *testing.B) {
 			ipRange:  1,
 			uaRange:  1,
 		},
-		// {
-		// 	name:     "ManyIPs_OneUA",
-		// 	duration: 5 * time.Second,
-		// 	ipRange:  100000,
-		// 	uaRange:  1,
-		// },
-		// {
-		// 	name:     "OneIP_ManyUAs",
-		// 	duration: 5 * time.Second,
-		// 	ipRange:  1,
-		// 	uaRange:  100000,
-		// },
-		// {
-		// 	name:     "ManyIPs_ManyUAs",
-		// 	duration: 5 * time.Second,
-		// 	ipRange:  100,
-		// 	uaRange:  10000,
-		// },
+		{
+			name:     "ManyIPs_OneUA",
+			duration: 5 * time.Second,
+			ipRange:  100000,
+			uaRange:  1,
+		},
+		{
+			name:     "OneIP_ManyUAs",
+			duration: 5 * time.Second,
+			ipRange:  1,
+			uaRange:  100000,
+		},
+		{
+			name:     "ManyIPs_ManyUAs",
+			duration: 5 * time.Second,
+			ipRange:  100,
+			uaRange:  10000,
+		},
 	}
 
 	for _, tt := range tests {

--- a/limits/ratelimiter_test.go
+++ b/limits/ratelimiter_test.go
@@ -171,7 +171,7 @@ func TestRateLimiter_IsLimited(t *testing.T) {
 		}
 	})
 	t.Run("redis errors", func(t *testing.T) {
-		s.FlushDB()
+		cleanRedis()
 
 		// Create a pool that will fail
 		failPool := &redis.Pool{

--- a/limits/ratelimiter_test.go
+++ b/limits/ratelimiter_test.go
@@ -1,0 +1,202 @@
+package limits
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis"
+	"github.com/gomodule/redigo/redis"
+)
+
+func TestRateLimiter_IsLimited(t *testing.T) {
+	// Start miniredis
+	s, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer s.Close()
+
+	pool := &redis.Pool{
+		MaxIdle:     3,
+		IdleTimeout: 240 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", s.Addr())
+		},
+	}
+
+	cleanRedis := func() {
+		conn := pool.Get()
+		defer conn.Close()
+		conn.Do("FLUSHDB")
+	}
+
+	// Clean up before all tests
+	cleanRedis()
+
+	// Clean up after all tests
+	defer cleanRedis()
+
+	t.Run("under limit", func(t *testing.T) {
+		cleanRedis()
+		rl := NewRateLimiter(pool, RateLimitConfig{
+			Interval:  time.Hour,
+			MaxEvents: 60,
+			KeyPrefix: "test:",
+		})
+
+		limited, err := rl.IsLimited("192.0.2.1", "test-agent")
+		if err != nil {
+			t.Fatalf("IsLimited() error = %v", err)
+		}
+		if limited {
+			t.Error("IsLimited() = true, want false")
+		}
+	})
+
+	t.Run("at limit", func(t *testing.T) {
+		cleanRedis()
+		rl := NewRateLimiter(pool, RateLimitConfig{
+			Interval:  time.Hour,
+			MaxEvents: 2,
+			KeyPrefix: "test:",
+		})
+
+		// First event
+		limited, err := rl.IsLimited("192.0.2.1", "test-agent")
+		if err != nil {
+			t.Fatalf("IsLimited() error = %v", err)
+		}
+		if limited {
+			t.Error("first event: IsLimited() = true, want false")
+		}
+
+		// Second event (should still be allowed)
+		limited, err = rl.IsLimited("192.0.2.1", "test-agent")
+		if err != nil {
+			t.Fatalf("IsLimited() error = %v", err)
+		}
+		if limited {
+			t.Error("second event: IsLimited() = true, want false")
+		}
+
+		// Third event (should be limited)
+		limited, err = rl.IsLimited("192.0.2.1", "test-agent")
+		if err != nil {
+			t.Fatalf("IsLimited() error = %v", err)
+		}
+		if !limited {
+			t.Error("third event: IsLimited() = false, want true")
+		}
+	})
+
+	t.Run("different ip not limited", func(t *testing.T) {
+		cleanRedis()
+		rl := NewRateLimiter(pool, RateLimitConfig{
+			Interval:  time.Hour,
+			MaxEvents: 2,
+			KeyPrefix: "test:",
+		})
+
+		// Add events for first IP
+		for i := 0; i < 2; i++ {
+			_, err := rl.IsLimited("192.0.2.1", "test-agent")
+			if err != nil {
+				t.Fatalf("IsLimited() error = %v", err)
+			}
+		}
+
+		// Different IP should not be limited
+		limited, err := rl.IsLimited("192.0.2.2", "test-agent")
+		if err != nil {
+			t.Fatalf("IsLimited() error = %v", err)
+		}
+		if limited {
+			t.Error("IsLimited() = true, want false")
+		}
+	})
+
+	t.Run("different ua not limited", func(t *testing.T) {
+		cleanRedis()
+		rl := NewRateLimiter(pool, RateLimitConfig{
+			Interval:  time.Hour,
+			MaxEvents: 2,
+			KeyPrefix: "test:",
+		})
+
+		// Add events for first UA
+		for i := 0; i < 2; i++ {
+			_, err := rl.IsLimited("192.0.2.1", "test-agent-1")
+			if err != nil {
+				t.Fatalf("IsLimited() error = %v", err)
+			}
+		}
+
+		// Different UA should not be limited
+		limited, err := rl.IsLimited("192.0.2.1", "test-agent-2")
+		if err != nil {
+			t.Fatalf("IsLimited() error = %v", err)
+		}
+		if limited {
+			t.Error("IsLimited() = true, want false")
+		}
+	})
+
+	t.Run("old events expire", func(t *testing.T) {
+		cleanRedis()
+		rl := NewRateLimiter(pool, RateLimitConfig{
+			Interval:  100 * time.Millisecond, // Short interval for testing
+			MaxEvents: 2,
+			KeyPrefix: "test:",
+		})
+
+		// First event
+		limited, err := rl.IsLimited("192.0.2.1", "test-agent")
+		if err != nil {
+			t.Fatalf("IsLimited() error = %v", err)
+		}
+		if limited {
+			t.Error("first event: IsLimited() = true, want false")
+		}
+
+		// Wait for event to expire
+		time.Sleep(200 * time.Millisecond)
+
+		// Should not be limited after expiration
+		limited, err = rl.IsLimited("192.0.2.1", "test-agent")
+		if err != nil {
+			t.Fatalf("IsLimited() error = %v", err)
+		}
+		if limited {
+			t.Error("IsLimited() = true, want false")
+		}
+	})
+	t.Run("redis errors", func(t *testing.T) {
+		s.FlushDB()
+
+		// Create a pool that will fail
+		failPool := &redis.Pool{
+			MaxIdle:     3,
+			IdleTimeout: 240 * time.Second,
+			Dial: func() (redis.Conn, error) {
+				// Use miniredis but close the connection immediately to simulate errors
+				conn, err := redis.Dial("tcp", s.Addr())
+				if err != nil {
+					return nil, err
+				}
+				conn.Close()
+				return conn, nil
+			},
+		}
+
+		rl := NewRateLimiter(failPool, RateLimitConfig{
+			Interval:  time.Hour,
+			MaxEvents: 2,
+			KeyPrefix: "test:",
+		})
+
+		_, err := rl.IsLimited("192.0.2.1", "test-agent")
+		if err == nil {
+			t.Error("IsLimited() with closed connection, want error, got nil")
+		}
+	})
+}

--- a/locate.go
+++ b/locate.go
@@ -78,7 +78,7 @@ func init() {
 	flag.Var(&keySource, "key-source", "Where to load signer and verifier keys")
 	flag.StringVar(&limitsPath, "limits-path", "/go/src/github.com/m-lab/locate/limits/config.yaml", "Path to the limits config file")
 	flag.DurationVar(&rateLimitInterval, "rate-limit-interval", time.Hour, "Time window for IP+UA rate limiting")
-	flag.IntVar(&rateLimitMax, "rate-limit-max", 5, "Max number of events in the time window for IP+UA rate limiting")
+	flag.IntVar(&rateLimitMax, "rate-limit-max", 40, "Max number of events in the time window for IP+UA rate limiting")
 	flag.StringVar(&rateLimitPrefix, "rate-limit-prefix", "locate:ratelimit:", "Prefix for Redis keys for IP+UA rate limiting")
 	flag.StringVar(&rateLimitRedisAddr, "rate-limit-redis-address", "", "Primary endpoint for Redis instance for rate limiting")
 	// Enable logging with line numbers to trace error locations.

--- a/locate.go
+++ b/locate.go
@@ -80,7 +80,7 @@ func init() {
 	flag.DurationVar(&rateLimitInterval, "rate-limit-interval", time.Hour, "Time window for IP+UA rate limiting")
 	flag.IntVar(&rateLimitMax, "rate-limit-max", 5, "Max number of events in the time window for IP+UA rate limiting")
 	flag.StringVar(&rateLimitPrefix, "rate-limit-prefix", "locate:ratelimit:", "Prefix for Redis keys for IP+UA rate limiting")
-	flag.StringVar(&rateLimitRedisAddr, "rate-limit-redis-addr", "", "Primary endpoint for Redis instance for rate limiting")
+	flag.StringVar(&rateLimitRedisAddr, "rate-limit-redis-address", "", "Primary endpoint for Redis instance for rate limiting")
 	// Enable logging with line numbers to trace error locations.
 	log.SetFlags(log.LUTC | log.Llongfile)
 }

--- a/locate.go
+++ b/locate.go
@@ -79,7 +79,7 @@ func init() {
 	flag.StringVar(&limitsPath, "limits-path", "/go/src/github.com/m-lab/locate/limits/config.yaml", "Path to the limits config file")
 	flag.DurationVar(&rateLimitInterval, "rate-limit-interval", time.Hour, "Time window for IP+UA rate limiting")
 	flag.IntVar(&rateLimitMax, "rate-limit-max", 40, "Max number of events in the time window for IP+UA rate limiting")
-	flag.StringVar(&rateLimitPrefix, "rate-limit-prefix", "locate:ratelimit:", "Prefix for Redis keys for IP+UA rate limiting")
+	flag.StringVar(&rateLimitPrefix, "rate-limit-prefix", "locate:ratelimit", "Prefix for Redis keys for IP+UA rate limiting")
 	flag.StringVar(&rateLimitRedisAddr, "rate-limit-redis-address", "", "Primary endpoint for Redis instance for rate limiting")
 	// Enable logging with line numbers to trace error locations.
 	log.SetFlags(log.LUTC | log.Llongfile)


### PR DESCRIPTION
Implements a rate limiter backed by Redis' sorted sets (ZSETs).

```
// It maintains a sliding window of events for each IP+UA combination, where:
//   - Each event is stored in a ZSET with the timestamp as score
//   - Old events (outside the window) are automatically removed
//   - Keys automatically expire after the configured interval
//
// The limiter considers a request to be rate-limited if the number of events
// in the current window exceeds MaxEvents.
```

Initially we are only going to log which IP+UA are being rate limited and increase a Prometheus counter. Once we confirm that the limiter is WAI, we can start actually rejecting requests.

I used a separate Redis instance because:
- The memorystore package appears to assume its Redis instance won't be used for anything else and expects all keys to be hashes (with a specific structure)
- I don't think we should create a single point of failure. If, for any reason, the memory usage of the rate limiter spikes and Redis can no longer handle queries, Locate will act conservatively by allowing the client's request to pass through. This way, the damage is minimized. However, we cannot afford to lose the heartbeat registrations.

Supersedes https://github.com/m-lab/locate/pull/210

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/211)
<!-- Reviewable:end -->
