### PR TITLE
Fix nil pointer in Nearest handler

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -176,7 +176,7 @@ func (c *Client) Nearest(rw http.ResponseWriter, req *http.Request) {
 				log.Printf("Rate limiter error: %v", err)
 			} else if limited {
 				metrics.RequestsTotal.WithLabelValues("nearest", "rate limit",
-					http.StatusText(result.Error.Status)).Inc()
+					http.StatusText(http.StatusTooManyRequests)).Inc()
 				// For now, we only log the rate limit exceeded message.
 				// TODO: Actually block the request and return an appropriate HTTP error
 				// code and message.


### PR DESCRIPTION
When I changed the handler to not actually block I kept a reference to `result` that's nil at that point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/212)
<!-- Reviewable:end -->
