### PR TITLE
Update rate limiter to have different configurable limits for IP-only and IP+UA

### DIFF
--- a/limits/ratelimiter.go
+++ b/limits/ratelimiter.go
@@ -8,83 +8,147 @@ import (
 	"github.com/gomodule/redigo/redis"
 )
 
-// RateLimitConfig holds the configuration for IP+UA rate limiting.
-type RateLimitConfig struct {
-	// Interval defines the duration of the sliding window.
+// LimitStatus indicates the result of a rate limit check
+type LimitStatus struct {
+	// IsLimited indicates if the request should be rate limited
+	IsLimited bool
+	// LimitType indicates which limit was exceeded ("ip" or "ipua" or "")
+	LimitType string
+}
+
+// LimitConfig holds the configuration for a single rate limit type
+type LimitConfig struct {
+	// Interval defines the duration of the sliding window
 	Interval time.Duration
-	// MaxEvents defines the maximum number of events allowed in the interval.
+
+	// MaxEvents defines the maximum number of events allowed in the interval
 	MaxEvents int
-	// KeyPrefix is the prefix for Redis keys.
+}
+
+// RateLimitConfig holds the configuration for both IP-only and IP+UA rate limiting.
+type RateLimitConfig struct {
+	// IPConfig defines the rate limiting configuration for IP-only checks
+	IPConfig LimitConfig
+
+	// IPUAConfig defines the rate limiting configuration for IP+UA checks
+	IPUAConfig LimitConfig
+
+	// KeyPrefix is the prefix for Redis keys
 	KeyPrefix string
 }
 
 // RateLimiter implements a distributed rate limiter using Redis sorted sets (ZSET).
-// It maintains a sliding window of events for each IP+UA combination, where:
+// It maintains sliding windows for both IP-only and IP+UA combinations, where:
 //   - Each event is stored in a ZSET with the timestamp as score
 //   - Old events (outside the window) are automatically removed
 //   - Keys automatically expire after the configured interval
 //
 // The limiter considers a request to be rate-limited if the number of events
-// in the current window exceeds MaxEvents.
+// in either window exceeds their respective MaxEvents.
 type RateLimiter struct {
-	pool      *redis.Pool
-	interval  time.Duration
-	maxEvents int
-	keyPrefix string
+	pool       *redis.Pool
+	ipConfig   LimitConfig
+	ipuaConfig LimitConfig
+	keyPrefix  string
 }
 
 // NewRateLimiter creates a new rate limiter.
 func NewRateLimiter(pool *redis.Pool, config RateLimitConfig) *RateLimiter {
 	return &RateLimiter{
-		pool:      pool,
-		interval:  config.Interval,
-		maxEvents: config.MaxEvents,
-		keyPrefix: config.KeyPrefix,
+		pool:       pool,
+		ipConfig:   config.IPConfig,
+		ipuaConfig: config.IPUAConfig,
+		keyPrefix:  config.KeyPrefix,
 	}
 }
 
-// generateKey creates a Redis key from IP and User-Agent.
-func (rl *RateLimiter) generateKey(ip, ua string) string {
+// generateIPKey creates a Redis key from IP only.
+func (rl *RateLimiter) generateIPKey(ip string) string {
+	return fmt.Sprintf("%s:%s", rl.keyPrefix, ip)
+}
+
+// generateIPUAKey creates a Redis key from IP and User-Agent.
+func (rl *RateLimiter) generateIPUAKey(ip, ua string) string {
+	// If User-Agent is empty, use "none" as the value. This allows to distinguish
+	// between IP-only keys and IPUA keys with an empty User-Agent.
+	if ua == "" {
+		ua = "none"
+	}
 	return fmt.Sprintf("%s:%s:%s", rl.keyPrefix, ip, ua)
 }
 
 // IsLimited checks if the given IP and User-Agent combination should be rate limited.
-func (rl *RateLimiter) IsLimited(ip, ua string) (bool, error) {
+// It first checks the IP-only limit, then the IP+UA limit if the IP-only check passes.
+func (rl *RateLimiter) IsLimited(ip, ua string) (LimitStatus, error) {
 	conn := rl.pool.Get()
 	defer conn.Close()
 
 	now := time.Now().UnixMicro()
-	windowStart := now - rl.interval.Microseconds()
-	redisKey := rl.generateKey(ip, ua)
+	ipKey := rl.generateIPKey(ip)
+	ipuaKey := rl.generateIPUAKey(ip, ua)
 
-	// Send all commands in pipeline.
-	// 1. Remove events outside the window
-	conn.Send("ZREMRANGEBYSCORE", redisKey, "-inf", windowStart)
-	// 2. Add current event
-	conn.Send("ZADD", redisKey, now, strconv.FormatInt(now, 10))
-	// 3. Set key expiration
-	conn.Send("EXPIRE", redisKey, int64(rl.interval.Seconds()))
-	// 4. Get total event count
-	conn.Send("ZCARD", redisKey)
+	// Start pipeline for both checks
+	// 1. IP-only check
+	conn.Send("ZREMRANGEBYSCORE", ipKey, "-inf", now-rl.ipConfig.Interval.Microseconds())
+	conn.Send("ZADD", ipKey, now, strconv.FormatInt(now, 10))
+	conn.Send("EXPIRE", ipKey, int64(rl.ipConfig.Interval.Seconds()))
+	conn.Send("ZCARD", ipKey)
+
+	// 2. IP+UA limit check
+	conn.Send("ZREMRANGEBYSCORE", ipuaKey, "-inf", now-rl.ipuaConfig.Interval.Microseconds())
+	conn.Send("ZADD", ipuaKey, now, strconv.FormatInt(now, 10))
+	conn.Send("EXPIRE", ipuaKey, int64(rl.ipuaConfig.Interval.Seconds()))
+	conn.Send("ZCARD", ipuaKey)
 
 	// Flush pipeline
 	if err := conn.Flush(); err != nil {
-		return false, fmt.Errorf("failed to flush pipeline: %w", err)
+		return LimitStatus{}, fmt.Errorf("failed to flush pipeline: %w", err)
 	}
 
-	// Receive all replies
+	// Receive first 3 replies for IP limit (ZREMRANGEBYSCORE, ZADD, EXPIRE)
 	for i := 0; i < 3; i++ {
-		// Receive replies for ZREMRANGEBYSCORE, ZADD, and EXPIRE
 		if _, err := conn.Receive(); err != nil {
-			return false, fmt.Errorf("failed to receive reply %d: %w", i, err)
+			return LimitStatus{}, fmt.Errorf("failed to receive IP limit reply %d: %w", i, err)
 		}
 	}
 
-	// Receive and process ZCARD reply
-	count, err := redis.Int64(conn.Receive())
+	// Receive IP limit count
+	ipCount, err := redis.Int64(conn.Receive())
 	if err != nil {
-		return false, fmt.Errorf("failed to receive count: %w", err)
+		return LimitStatus{}, fmt.Errorf("failed to receive IP limit count: %w", err)
 	}
 
-	return count > int64(rl.maxEvents), nil
+	// Check IP-only limit first
+	if ipCount > int64(rl.ipConfig.MaxEvents) {
+		return LimitStatus{
+			IsLimited: true,
+			LimitType: "ip",
+		}, nil
+	}
+
+	// Receive next 3 replies for IP+UA limit (ZREMRANGEBYSCORE, ZADD, EXPIRE)
+	for i := 0; i < 3; i++ {
+		if _, err := conn.Receive(); err != nil {
+			return LimitStatus{}, fmt.Errorf("failed to receive IP+UA limit reply %d: %w", i, err)
+		}
+	}
+
+	// Receive IP+UA limit count
+	ipuaCount, err := redis.Int64(conn.Receive())
+	if err != nil {
+		return LimitStatus{}, fmt.Errorf("failed to receive IP+UA limit count: %w", err)
+	}
+
+	// Check IP+UA limit
+	if ipuaCount > int64(rl.ipuaConfig.MaxEvents) {
+		return LimitStatus{
+			IsLimited: true,
+			LimitType: "ipua",
+		}, nil
+	}
+
+	return LimitStatus{
+		IsLimited: false,
+		LimitType: "",
+	}, nil
 }

--- a/limits/ratelimiter_bench_test.go
+++ b/limits/ratelimiter_bench_test.go
@@ -38,10 +38,16 @@ func BenchmarkRateLimiter_RealWorld(b *testing.B) {
 		},
 	}
 
-	// Create rate limiter with 60 requests/hour limit
+	// Create rate limiter with different limits for IP and IP+UA
 	limiter := NewRateLimiter(pool, RateLimitConfig{
-		Interval:  time.Hour,
-		MaxEvents: 60,
+		IPConfig: LimitConfig{
+			Interval:  time.Hour,
+			MaxEvents: 120, // More permissive IP-only limit
+		},
+		IPUAConfig: LimitConfig{
+			Interval:  time.Hour,
+			MaxEvents: 60, // Stricter IP+UA limit
+		},
 		KeyPrefix: "benchmark:",
 	})
 
@@ -59,8 +65,10 @@ func BenchmarkRateLimiter_RealWorld(b *testing.B) {
 	tests := []struct {
 		name     string
 		duration time.Duration
-		ipRange  int // Number of unique IPs
-		uaRange  int // Number of unique UAs
+		ipRange  int  // Number of unique IPs
+		uaRange  int  // Number of unique UAs
+		ipOnly   bool // Whether to test IP-only limiting
+
 	}{
 		{
 			name:    "SingleIPUA_Long",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,9 +23,9 @@ var (
 	RateLimitedTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "locate_rate_limited_total",
-			Help: "Total number of rate-limited requests by client name",
+			Help: "Total number of rate-limited requests by client and limit type",
 		},
-		[]string{"clientname"},
+		[]string{"clientname", "type"},
 	)
 
 	// AppEngineTotal counts the number of times App Engine headers are


### PR DESCRIPTION
This allows to have different per-IP and per-IP+UA intervals and thresholds. If the IP address made more than X requests in Y time, the IP+UA key is ignored.

Adds the `-rate-limit-ip-interval` and `-rate-limit-ip-max` to configure this new rate limiting rule.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/219)
<!-- Reviewable:end -->
