### PR TITLE
Add -early-exit-clients command-line flag

### DIFF
--- a/cloudbuild/app.yaml.mlab-ns.template
+++ b/cloudbuild/app.yaml.mlab-ns.template
@@ -44,3 +44,4 @@ env_variables:
   RATE_LIMIT_IP_MAX: {{RATE_LIMIT_IP_MAX}}
   PROMETHEUSX_LISTEN_ADDRESS: ':9090' # Must match one of the forwarded_ports above.
   PROMETHEUS_URL: 'https://prometheus-basicauth.{{PLATFORM_PROJECT}}.measurementlab.net/'
+  EARLY_EXIT_CLIENTS: {{EARLY_EXIT_CLIENTS}}

--- a/cloudbuild/app.yaml.template
+++ b/cloudbuild/app.yaml.template
@@ -43,3 +43,4 @@ env_variables:
   RATE_LIMIT_IP_MAX: {{RATE_LIMIT_IP_MAX}}
   PROMETHEUSX_LISTEN_ADDRESS: ':9090' # Must match one of the forwarded_ports above.
   PROMETHEUS_URL: 'https://prometheus-basicauth.{{PLATFORM_PROJECT}}.measurementlab.net/'
+  EARLY_EXIT_CLIENTS: {{EARLY_EXIT_CLIENTS}}

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -34,6 +34,7 @@ steps:
         -e 's/{{RATE_LIMIT_MAX}}/$_RATE_LIMIT_MAX/'
         -e 's/{{RATE_LIMIT_IP_INTERVAL}}/$_RATE_LIMIT_IP_INTERVAL/'
         -e 's/{{RATE_LIMIT_IP_MAX}}/$_RATE_LIMIT_IP_MAX/'
+        -e 's/{{EARLY_EXIT_CLIENTS}}/$_EARLY_EXIT_CLIENTS/'
         app.yaml
       - gcloud --project $PROJECT_ID app deploy --promote app.yaml
       # After deploying the new service, deploy the openapi spec.
@@ -57,6 +58,7 @@ steps:
         -e 's/{{RATE_LIMIT_MAX}}/$_RATE_LIMIT_MAX/'
         -e 's/{{RATE_LIMIT_IP_INTERVAL}}/$_RATE_LIMIT_IP_INTERVAL/'
         -e 's/{{RATE_LIMIT_IP_MAX}}/$_RATE_LIMIT_IP_MAX/'
+        -e 's/{{EARLY_EXIT_CLIENTS}}/$_EARLY_EXIT_CLIENTS/'
         app.yaml
       - gcloud --project $PROJECT_ID app deploy --no-promote app.yaml
       # After deploying the new service, deploy the openapi spec.

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -54,9 +54,10 @@ type Client struct {
 	LocatorV2
 	ClientLocator
 	PrometheusClient
-	targetTmpl  *template.Template
-	agentLimits limits.Agents
-	ipLimiter   Limiter
+	targetTmpl       *template.Template
+	agentLimits      limits.Agents
+	ipLimiter        Limiter
+	earlyExitClients map[string]bool
 }
 
 // LocatorV2 defines how the Nearest handler requests machines nearest to the
@@ -90,7 +91,12 @@ func init() {
 
 // NewClient creates a new client.
 func NewClient(project string, private Signer, locatorV2 LocatorV2, client ClientLocator,
-	prom PrometheusClient, lmts limits.Agents, limiter Limiter) *Client {
+	prom PrometheusClient, lmts limits.Agents, limiter Limiter, earlyExitClients []string) *Client {
+	// Convert slice to map for O(1) lookups
+	earlyExitMap := make(map[string]bool)
+	for _, client := range earlyExitClients {
+		earlyExitMap[client] = true
+	}
 	return &Client{
 		Signer:           private,
 		project:          project,
@@ -100,6 +106,7 @@ func NewClient(project string, private Signer, locatorV2 LocatorV2, client Clien
 		targetTmpl:       template.Must(template.New("name").Parse("{{.Hostname}}{{.Ports}}")),
 		agentLimits:      lmts,
 		ipLimiter:        limiter,
+		earlyExitClients: earlyExitMap,
 	}
 }
 
@@ -116,8 +123,9 @@ func NewClientDirect(project string, private Signer, locatorV2 LocatorV2, client
 	}
 }
 
-func extraParams(hostname string, index int, p paramOpts) url.Values {
+func (c *Client) extraParams(hostname string, index int, p paramOpts) url.Values {
 	v := url.Values{}
+
 	// Add client parameters.
 	for key := range p.raw {
 		if strings.HasPrefix(key, "client_") {
@@ -129,6 +137,12 @@ func extraParams(hostname string, index int, p paramOpts) url.Values {
 		if ok && rand.Float64() < val {
 			v.Set(key, p.raw.Get(key))
 		}
+	}
+
+	// Add early_exit parameter for specified clients
+	clientName := p.raw.Get("client_name")
+	if clientName != "" && c.earlyExitClients[clientName] {
+		v.Set("early_exit", "250")
 	}
 
 	// Add Locate Service version.
@@ -323,7 +337,7 @@ func (c *Client) checkClientLocation(rw http.ResponseWriter, req *http.Request) 
 func (c *Client) populateURLs(targets []v2.Target, ports static.Ports, exp string, pOpts paramOpts) {
 	for i, target := range targets {
 		token := c.getAccessToken(target.Machine, exp)
-		params := extraParams(target.Machine, i, pOpts)
+		params := c.extraParams(target.Machine, i, pOpts)
 		targets[i].URLs = c.getURLs(ports, target.Hostname, token, params)
 	}
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -142,7 +142,7 @@ func (c *Client) extraParams(hostname string, index int, p paramOpts) url.Values
 	// Add early_exit parameter for specified clients
 	clientName := p.raw.Get("client_name")
 	if clientName != "" && c.earlyExitClients[clientName] {
-		v.Set("early_exit", "250")
+		v.Set(static.EarlyExitParameter, static.EarlyExitDefaultValue)
 	}
 
 	// Add Locate Service version.

--- a/handler/heartbeat_test.go
+++ b/handler/heartbeat_test.go
@@ -70,7 +70,7 @@ func TestClient_handleHeartbeats(t *testing.T) {
 func fakeClient(t heartbeat.StatusTracker) *Client {
 	locatorv2 := fakeLocatorV2{StatusTracker: t}
 	return NewClient("mlab-sandbox", &fakeSigner{}, &locatorv2,
-		clientgeo.NewAppEngineLocator(), prom.NewAPI(nil), nil, nil)
+		clientgeo.NewAppEngineLocator(), prom.NewAPI(nil), nil, nil, nil)
 }
 
 type fakeConn struct {

--- a/handler/monitoring_test.go
+++ b/handler/monitoring_test.go
@@ -92,7 +92,7 @@ func TestClient_Monitoring(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cl := clientgeo.NewAppEngineLocator()
-			c := NewClient("mlab-sandbox", tt.signer, tt.locator, cl, prom.NewAPI(nil), nil, nil)
+			c := NewClient("mlab-sandbox", tt.signer, tt.locator, cl, prom.NewAPI(nil), nil, nil, nil)
 			rw := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, "/v2/platform/monitoring/"+tt.path, nil)
 			req = req.Clone(controller.SetClaim(req.Context(), tt.claim))

--- a/locate.go
+++ b/locate.go
@@ -60,6 +60,8 @@ var (
 	rateLimitIPUAMax      int
 	rateLimitIPInterval   time.Duration
 	rateLimitIPMax        int
+
+	earlyExitClients flagx.StringArray
 )
 
 func init() {
@@ -88,6 +90,7 @@ func init() {
 		"Max number of events in the time window for IP-only rate limiting")
 	flag.StringVar(&rateLimitPrefix, "rate-limit-prefix", "locate:ratelimit", "Prefix for Redis keys for IP+UA rate limiting")
 	flag.StringVar(&rateLimitRedisAddr, "rate-limit-redis-address", "", "Primary endpoint for Redis instance for rate limiting")
+	flag.Var(&earlyExitClients, "early-exit-client", "Client names that should receive early_exit parameter (can be specified multiple times)")
 	// Enable logging with line numbers to trace error locations.
 	log.SetFlags(log.LUTC | log.Llongfile)
 }
@@ -173,7 +176,8 @@ func main() {
 
 	lmts, err := limits.ParseConfig(limitsPath)
 	rtx.Must(err, "failed to parse limits config")
-	c := handler.NewClient(project, signer, srvLocatorV2, locators, promClient, lmts, ipLimiter)
+	c := handler.NewClient(project, signer, srvLocatorV2, locators, promClient,
+		lmts, ipLimiter, earlyExitClients)
 
 	go func() {
 		// Check and reload db at least once a day.

--- a/locate.go
+++ b/locate.go
@@ -90,7 +90,7 @@ func init() {
 		"Max number of events in the time window for IP-only rate limiting")
 	flag.StringVar(&rateLimitPrefix, "rate-limit-prefix", "locate:ratelimit", "Prefix for Redis keys for IP+UA rate limiting")
 	flag.StringVar(&rateLimitRedisAddr, "rate-limit-redis-address", "", "Primary endpoint for Redis instance for rate limiting")
-	flag.Var(&earlyExitClients, "early-exit-client", "Client names that should receive early_exit parameter (can be specified multiple times)")
+	flag.Var(&earlyExitClients, "early-exit-clients", "Client names that should receive early_exit parameter (can be specified multiple times)")
 	// Enable logging with line numbers to trace error locations.
 	log.SetFlags(log.LUTC | log.Llongfile)
 }

--- a/static/configs.go
+++ b/static/configs.go
@@ -30,6 +30,7 @@ const (
 	RegistrationLoadMax        = 24 * time.Hour
 	EarthHalfCircumferenceKm   = 20038
 	EarlyExitParameter         = "early_exit"
+	EarlyExitDefaultValue      = "250"
 	MaxCwndGainParameter       = "max_cwnd_gain"
 	MaxElapsedTimeParameter    = "max_elapsed_time"
 	CountryParameter           = "country"


### PR DESCRIPTION
This flag allows to specify a list of clients that we know support early exit and for which early exit should always be added to the generated URLs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/223)
<!-- Reviewable:end -->
