### PR TITLE
Avoids a nil pointer dereference error in Geo()

### DIFF
--- a/siteinfo/siteinfo.go
+++ b/siteinfo/siteinfo.go
@@ -43,10 +43,10 @@ func Geo(msgs map[string]v2.HeartbeatMessage, v url.Values) (*geojson.FeatureCol
 		}
 
 		// We have witnessed a case in staging where a v2.HeartbeatMessage's
-		// Registration filed was nil for some reason. It's not clear under
+		// Registration field was nil for some reason. It's not clear under
 		// what circumstances this error condition can happen, but skip this
 		// host if Registration is nil to avoid panics when trying to
-		// dereferencing a nil pointer.
+		// dereference a nil pointer.
 		if h.Registration == nil {
 			continue
 		}

--- a/siteinfo/siteinfo_test.go
+++ b/siteinfo/siteinfo_test.go
@@ -300,6 +300,19 @@ func TestGeo(t *testing.T) {
 			},
 		},
 		{
+			name: "success-missing-data",
+			instances: map[string]v2.HeartbeatMessage{
+				"ndt-mlab3-mia0t.mlab-sandbox.measurement-lab.org": {
+					Health:       nil,
+					Registration: nil,
+					Prometheus: &v2.Prometheus{
+						Health: false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "error",
 			instances: map[string]v2.HeartbeatMessage{
 				"invalid.hostname": {},


### PR DESCRIPTION
There was a case in staging where Locate was returning this for a host:

  "neubot-mlab4-syd04.mlab-staging.measurement-lab.org": {
    "Health": null,
    "Registration": null,
    "Prometheus": {
      "Health": false
    }
  },

... this was causing a panic in Locate. This commit avoids this, and adds a new unit test to be sure it working as intended. Interestingly, syd04 was retired in 2023, so it's not clear why Locate is hanging on to a record for this machine.

I also renamed `v` in the for loop to `h` to avoid being confusion with the `v` function parameter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/227)
<!-- Reviewable:end -->
