### PR TITLE
feat(auth): Add JWT authentication for heartbeat endpoints

### DIFF
--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -154,6 +154,13 @@ func main() {
 
 	// Establish a connection with JWT authentication.
 	conn := connection.NewConn()
+	
+	// Set up JWT token refresh for automatic token renewal
+	conn.SetTokenRefresher(func() (string, error) {
+		log.Printf("Refreshing JWT token...")
+		return getJWTTokenFunc(apiKey, tokenExchangeURL)
+	})
+	
 	err = conn.Dial(heartbeatURL, headers, hbm)
 	rtx.Must(err, "failed to establish a websocket connection with %s", heartbeatURL)
 

--- a/cmd/heartbeat/main.go
+++ b/cmd/heartbeat/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -29,7 +31,7 @@ import (
 
 var (
 	heartbeatURL        string
-	hostname			flagx.StringFile
+	hostname            flagx.StringFile
 	experiment          string
 	pod                 string
 	node                string
@@ -41,11 +43,58 @@ var (
 	heartbeatPeriod     = static.HeartbeatPeriod
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 	lbPath              = "/metadata/loadbalanced"
+
+	// JWT authentication parameters
+	apiKey           string
+	tokenExchangeURL string
 )
 
 // Checker generates a health score for the heartbeat instance (0, 1).
 type Checker interface {
 	GetHealth(ctx context.Context) float64 // Health score.
+}
+
+// TokenResponse represents the response from the token exchange service
+type TokenResponse struct {
+	Token string `json:"token"`
+}
+
+// getJWTTokenFunc is a variable that holds the JWT token function, allowing for test overrides
+var getJWTTokenFunc = getJWTToken
+
+// getJWTToken exchanges an API key for a JWT token
+func getJWTToken(apiKey, tokenExchangeURL string) (string, error) {
+	// Prepare the request payload
+	payload := map[string]string{
+		"api_key": apiKey,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal token request: %w", err)
+	}
+
+	// Make the HTTP request to the token exchange service
+	resp, err := http.Post(tokenExchangeURL, "application/json", bytes.NewBuffer(payloadBytes))
+	if err != nil {
+		return "", fmt.Errorf("failed to request JWT token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token exchange failed with status %d", resp.StatusCode)
+	}
+
+	// Parse the response
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	if tokenResp.Token == "" {
+		return "", fmt.Errorf("empty token received from exchange service")
+	}
+
+	return tokenResp.Token, nil
 }
 
 func init() {
@@ -59,11 +108,22 @@ func init() {
 	flag.Var(&kubernetesURL, "kubernetes-url", "URL for Kubernetes API")
 	flag.Var(&registrationURL, "registration-url", "URL for site registration")
 	flag.Var(&services, "services", "Maps experiment target names to their set of services")
+	flag.StringVar(&apiKey, "api-key", "", "API key for JWT token exchange (required)")
+	flag.StringVar(&tokenExchangeURL, "token-exchange-url", "https://auth.mlab-sandbox.measurementlab.net/v0/token/autojoin",
+		"URL for token exchange service")
 }
 
 func main() {
 	flag.Parse()
 	rtx.Must(flagx.ArgsFromEnvWithLog(flag.CommandLine, false), "failed to read args from env")
+
+	// Validate JWT authentication parameters
+	if apiKey == "" {
+		log.Fatal("API key is required for JWT authentication (-api-key flag)")
+	}
+	if tokenExchangeURL == "" {
+		log.Fatal("Token exchange URL is required (-token-exchange-url flag)")
+	}
 
 	// Start metrics server.
 	prom := prometheusx.MustServeMetrics()
@@ -82,9 +142,19 @@ func main() {
 	rtx.Must(err, "could not load registration data")
 	hbm := v2.HeartbeatMessage{Registration: r}
 
-	// Establish a connection.
+	// Get JWT token for authentication
+	log.Printf("Exchanging API key for JWT token...")
+	jwtToken, err := getJWTTokenFunc(apiKey, tokenExchangeURL)
+	rtx.Must(err, "failed to get JWT token")
+	log.Printf("Successfully obtained JWT token")
+
+	// Prepare headers with JWT authentication
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer "+jwtToken)
+
+	// Establish a connection with JWT authentication.
 	conn := connection.NewConn()
-	err = conn.Dial(heartbeatURL, http.Header{}, hbm)
+	err = conn.Dial(heartbeatURL, headers, hbm)
 	rtx.Must(err, "failed to establish a websocket connection with %s", heartbeatURL)
 
 	probe := health.NewPortProbe(svcs)

--- a/cmd/heartbeat/main_test.go
+++ b/cmd/heartbeat/main_test.go
@@ -17,6 +17,14 @@ import (
 )
 
 func Test_main(t *testing.T) {
+	// Override the JWT token function for testing
+	getJWTTokenFunc = func(apiKey, tokenExchangeURL string) (string, error) {
+		return "fake-jwt-token", nil
+	}
+	defer func() {
+		getJWTTokenFunc = getJWTToken // restore original function
+	}()
+
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 	fh := testdata.FakeHandler{}
 	s := testdata.FakeServer(fh.Upgrade)
@@ -36,6 +44,8 @@ func Test_main(t *testing.T) {
 	flag.Set("namespace", "default")
 	flag.Set("registration-url", "file:./registration/testdata/registration.json")
 	flag.Set("services", "ndt/ndt7=ws://:"+u.Port()+"/ndt/v7/download")
+	flag.Set("api-key", "test-api-key")
+	flag.Set("token-exchange-url", "http://fake-token-exchange.example.com/token")
 
 	heartbeatPeriod = 2 * time.Second
 	timer := time.NewTimer(2 * heartbeatPeriod)

--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -200,6 +200,85 @@ func TestWriteMessage_ClosedServer(t *testing.T) {
 	}
 }
 
+func Test_TokenRefresh(t *testing.T) {
+	c := NewConn()
+	
+	// Track token refresh calls
+	refreshCount := 0
+	c.SetTokenRefresher(func() (string, error) {
+		refreshCount++
+		// Return a JWT token that expires in 2 hours (won't need refresh)
+		return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.fake-signature", nil
+	})
+	
+	// Set up headers with an expired JWT token
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MDA5MzUzMDB9.fake-signature") // Expired in 2020
+	c.header = headers
+	
+	fh := testdata.FakeHandler{}
+	s := testdata.FakeServer(fh.Upgrade)
+	defer close(c, s)
+	
+	// Call refreshJWTIfNeeded directly (since connect() is hard to test)
+	err := c.refreshJWTIfNeeded()
+	if err != nil {
+		t.Errorf("refreshJWTIfNeeded() failed: %v", err)
+	}
+	
+	// Token refresh should have been called due to expired token
+	if refreshCount != 1 {
+		t.Errorf("Expected 1 token refresh call, got %d", refreshCount)
+	}
+	
+	// Check that the Authorization header was updated
+	newAuth := c.header.Get("Authorization")
+	expectedAuth := "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.fake-signature"
+	if newAuth != expectedAuth {
+		t.Errorf("Authorization header not updated. Got: %s, Expected: %s", newAuth, expectedAuth)
+	}
+}
+
+func Test_TokenRefresh_NoRefresher(t *testing.T) {
+	c := NewConn()
+	// Don't set a token refresher
+	
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MDA5MzUzMDB9.fake-signature") // Expired token
+	c.header = headers
+	
+	// Should not fail even with expired token and no refresher
+	err := c.refreshJWTIfNeeded()
+	if err != nil {
+		t.Errorf("refreshJWTIfNeeded() should not fail without refresher: %v", err)
+	}
+}
+
+func Test_TokenRefresh_ValidToken(t *testing.T) {
+	c := NewConn()
+	
+	refreshCount := 0
+	c.SetTokenRefresher(func() (string, error) {
+		refreshCount++
+		return "new-token", nil
+	})
+	
+	headers := http.Header{}
+	// Token that expires far in the future (won't need refresh)
+	headers.Set("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.fake-signature")
+	c.header = headers
+	
+	err := c.refreshJWTIfNeeded()
+	if err != nil {
+		t.Errorf("refreshJWTIfNeeded() failed: %v", err)
+	}
+	
+	// Should not refresh since token is still valid
+	if refreshCount != 0 {
+		t.Errorf("Expected 0 token refresh calls for valid token, got %d", refreshCount)
+	}
+}
+
 func close(c *Conn, s *httptest.Server) {
 	c.Close()
 	s.Close()

--- a/handler/heartbeat.go
+++ b/handler/heartbeat.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"gopkg.in/square/go-jose.v2/jwt"
-	
+
 	"github.com/m-lab/go/host"
 	v2 "github.com/m-lab/locate/api/v2"
 	"github.com/m-lab/locate/metrics"
@@ -162,26 +162,26 @@ func (c *Client) extractJWTClaims(req *http.Request) (map[string]interface{}, er
 	if authHeader == "" {
 		return nil, fmt.Errorf("Authorization header not found")
 	}
-	
+
 	// Extract the token (remove "Bearer " prefix)
 	const bearerPrefix = "Bearer "
 	if !strings.HasPrefix(authHeader, bearerPrefix) {
 		return nil, fmt.Errorf("Authorization header does not contain Bearer token")
 	}
 	token := strings.TrimPrefix(authHeader, bearerPrefix)
-	
+
 	// Parse the JWT token without validation (Cloud Endpoints already validated it)
 	parsed, err := jwt.ParseSigned(token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse JWT token: %w", err)
 	}
-	
+
 	// Extract all claims (both standard and custom) without verification
 	var claims map[string]interface{}
 	if err := parsed.UnsafeClaimsWithoutVerification(&claims); err != nil {
 		return nil, fmt.Errorf("failed to extract JWT claims: %w", err)
 	}
-	
+
 	return claims, nil
 }
 
@@ -191,16 +191,16 @@ func (c *Client) extractOrgClaim(claims map[string]interface{}) (string, error) 
 	if !ok {
 		return "", fmt.Errorf("org claim not found in JWT")
 	}
-	
+
 	org, ok := orgClaim.(string)
 	if !ok {
 		return "", fmt.Errorf("org claim is not a string")
 	}
-	
+
 	if org == "" {
 		return "", fmt.Errorf("org claim is empty")
 	}
-	
+
 	return org, nil
 }
 
@@ -209,18 +209,18 @@ func (c *Client) validateOrganization(org, hostname string) error {
 	if hostname == "" {
 		return fmt.Errorf("hostname is empty")
 	}
-	
+
 	// Parse the hostname using M-Lab's host package
 	parsed, err := host.Parse(hostname)
 	if err != nil {
 		return fmt.Errorf("failed to parse hostname %s: %w", hostname, err)
 	}
-	
+
 	// Compare the organization from the hostname with the JWT org claim
 	if parsed.Org != org {
-		return fmt.Errorf("organization mismatch: JWT org=%s, hostname org=%s (hostname: %s)", 
+		return fmt.Errorf("organization mismatch: JWT org=%s, hostname org=%s (hostname: %s)",
 			org, parsed.Org, hostname)
 	}
-	
+
 	return nil
 }

--- a/handler/heartbeat_test.go
+++ b/handler/heartbeat_test.go
@@ -59,7 +59,7 @@ func TestClient_handleHeartbeats(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fakeClient(tt.tracker)
-			err := c.handleHeartbeats(tt.ws)
+			err := c.handleHeartbeats(tt.ws, nil)
 			if !errors.Is(err, wantErr) {
 				t.Errorf("Client.handleHeartbeats() error = %v, wantErr %v", err, wantErr)
 			}

--- a/locate.go
+++ b/locate.go
@@ -215,10 +215,15 @@ func main() {
 
 	mux := http.NewServeMux()
 	// PLATFORM APIs
-	// Services report their health to the heartbeat service.
+	// Services report their health to the heartbeat service (API key protected).
 	mux.HandleFunc("/v2/platform/heartbeat", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(promet.Labels{"path": "/v2/platform/heartbeat"}),
 		http.HandlerFunc(c.Heartbeat)))
+	// Services report their health to the heartbeat service (JWT protected with org validation).
+	// JWT verification is handled by Cloud Endpoints.
+	mux.HandleFunc("/v2/platform/heartbeat-jwt", promhttp.InstrumentHandlerDuration(
+		metrics.RequestHandlerDuration.MustCurryWith(promet.Labels{"path": "/v2/platform/heartbeat-jwt"}),
+		http.HandlerFunc(c.HeartbeatJWT)))
 	// Collect Prometheus health signals.
 	mux.HandleFunc("/v2/platform/prometheus", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(promet.Labels{"path": "/v2/platform/prometheus"}),

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -124,13 +124,32 @@ paths:
   "/v2/platform/heartbeat":
     get:
       description: |-
-        Platform-specific path.
+        Platform-specific path. Protected by API key authentication.
       operationId: "v2-platform-heartbeat"
       responses:
         '200':
           description: OK.
       security:
       - api_key: []
+      tags:
+        - platform
+
+  "/v2/platform/heartbeat-jwt":
+    get:
+      description: |-
+        Platform-specific path. Protected by JWT authentication with organization validation.
+        The JWT token must include an "org" claim that matches the organization in the hostname
+        of any heartbeat registration or health update messages.
+      operationId: "v2-platform-heartbeat-jwt"
+      responses:
+        '200':
+          description: OK.
+        '401':
+          description: Unauthorized - invalid JWT token or missing/invalid org claim.
+        '403':
+          description: Forbidden - organization mismatch between JWT and hostname.
+      security:
+      - jwt_auth: []
       tags:
         - platform
 
@@ -264,6 +283,19 @@ securityDefinitions:
       or allocated by M-Lab for your client integration.
     name: "key"
     in: "query"
+
+  # This section configures JWT authentication for heartbeat endpoints.
+  # Paths configured with jwt_auth security require a valid JWT token with an "org" claim.
+  jwt_auth:
+    authorizationUrl: "" # Required for swagger 2.0 oauth2, but not used by ESPv2/Apigee
+    flow: "implicit" # Required for swagger 2.0 oauth2, but not used by ESPv2/Apigee
+    type: "oauth2"
+    # x-google-jwks_uri and x-google-issuer identify the service that issues JWTs.
+    x-google-issuer: "token-exchange"
+    x-google-jwks_uri: "https://auth.{{PROJECT}}.measurementlab.net/.well-known/jwks.json"
+    # x-google-audiences are the audiences JWTs are allowed to target.
+    # The value should be the backend service name, which is derived from the 'host' field.
+    x-google-audiences: "locate-dot-{{PROJECT}}.appspot.com"
 
 tags:
   - name: public

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -294,8 +294,8 @@ securityDefinitions:
     x-google-issuer: "token-exchange"
     x-google-jwks_uri: "https://auth.{{PROJECT}}.measurementlab.net/.well-known/jwks.json"
     # x-google-audiences are the audiences JWTs are allowed to target.
-    # The value should be the backend service name, which is derived from the 'host' field.
-    x-google-audiences: "locate-dot-{{PROJECT}}.appspot.com"
+    # The audience must match the JWT token audience from token-exchange service.
+    x-google-audiences: "autojoin"
 
 tags:
   - name: public


### PR DESCRIPTION
## Summary
- Adds JWT-protected `/v2/platform/heartbeat-jwt` endpoint with organization validation
- Updates heartbeat client to use JWT authentication with automatic token refresh
- Maintains backward compatibility with existing API key endpoint