### PR TITLE
fix: use PLATFORM_PROJECT for the auth service in openapi.yaml

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -38,7 +38,7 @@ steps:
         app.yaml
       - gcloud --project $PROJECT_ID app deploy --promote app.yaml
       # After deploying the new service, deploy the openapi spec.
-      - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{AUTH_PROJECT}}/$_AUTH_PROJECT_ID/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
+      - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/' -e 's/{{DEPLOYMENT}}/$PROJECT_ID/' openapi.yaml
       - gcloud endpoints services deploy openapi.yaml
 
   # Deployment of APIs in mlab-ns.
@@ -62,5 +62,5 @@ steps:
         app.yaml
       - gcloud --project $PROJECT_ID app deploy --no-promote app.yaml
       # After deploying the new service, deploy the openapi spec.
-      - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{AUTH_PROJECT}}/$_AUTH_PROJECT_ID/' -e 's/{{DEPLOYMENT}}/Production/' openapi.yaml
+      - sed -i -e 's/{{PROJECT}}/$PROJECT_ID/' -e 's/{{PLATFORM_PROJECT}}/$_PLATFORM_PROJECT/' -e 's/{{DEPLOYMENT}}/Production/' openapi.yaml
       - gcloud endpoints services deploy openapi.yaml

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -292,7 +292,7 @@ securityDefinitions:
     type: "oauth2"
     # x-google-jwks_uri and x-google-issuer identify the service that issues JWTs.
     x-google-issuer: "token-exchange"
-    x-google-jwks_uri: "https://auth.{{AUTH_PROJECT}}.measurementlab.net/.well-known/jwks.json"
+    x-google-jwks_uri: "https://auth.{{PLATFORM_PROJECT}}.measurementlab.net/.well-known/jwks.json"
     # x-google-audiences are the audiences JWTs are allowed to target.
     # The audience must match the JWT token audience from token-exchange service.
     x-google-audiences: "autojoin"


### PR DESCRIPTION
Use `_PLATFORM_PROJECT` instead of `PROJECT_ID` in OpenAPI configuration to handle deployment scenarios where the auth service runs in a different GCP project (e.g., mlab-ns deployment where auth service is in mlab-oti).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/229)
<!-- Reviewable:end -->
