### PR TITLE
feat: minimal mlab-ns compatibility shim

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,6 +48,11 @@ linters:
       disabled-checks:
         - commentFormatting
         - hugeParam
+        # sloppyLen's only useful patterns (len(x) >= 0 always true,
+        # len(x) < 0 always false) are already caught by staticcheck.
+        # Its remaining check (len(x) <= 0 → len(x) == 0) is a style
+        # preference that conflicts with defensive domain-exclusion style.
+        - sloppyLen
 
     staticcheck:
       checks:

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/rafaeljusto/redigomock v2.4.0+incompatible
 	github.com/sirupsen/logrus v1.9.4
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.51.0
 	google.golang.org/api v0.269.0
 	google.golang.org/genproto v0.0.0-20260128011058-8636f8732409
@@ -70,6 +71,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.12 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
@@ -90,6 +92,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -543,13 +543,23 @@ func (c *Client) limitRequest(now time.Time, req *http.Request) bool {
 	return l.IsLimited(now)
 }
 
-// setHeaders sets the response headers for "nearest" requests.
+// setHeaders sets the response headers for "nearest" requests and
+// other similar requests where we need:
+//
+// 1. Content-Type equal to application/json
+//
+// 2. Cache-Control equal to no-store
+//
+// 3. CORS headers
 func setHeaders(rw http.ResponseWriter) {
-	// Set CORS policy to allow third-party websites to use returned resources.
+	// Set the content-type header to imply we will return JSON
 	rw.Header().Set("Content-Type", "application/json")
+
+	// Set CORS policy to allow third-party websites to use returned resources.
 	rw.Header().Set("Access-Control-Allow-Origin", "*")
 	rw.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 	rw.Header().Set("Access-Control-Allow-Headers", "Authorization")
+
 	// Prevent caching of result.
 	// See also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 	rw.Header().Set("Cache-Control", "no-store")

--- a/handler/mlabnscompat.go
+++ b/handler/mlabnscompat.go
@@ -1,0 +1,278 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/m-lab/go/host"
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/locate/metrics"
+)
+
+// MLabNSCompat handles mlab-ns `/ndt` and returns a compatible response.
+//
+// # Motivation
+//
+// According to https://www.measurementlab.net/blog/retiring-ndt5-raw/ ndt5 should
+// have discontinued in January, 2024 along with mlab-ns. However, for technical
+// reasons, there are still known mlab-ns integrators that needs a minimal amount
+// of mlab-ns backward compatibility to finish their migrations.
+//
+// What they specifically need is for these URLs:
+//
+//	https://mlab-ns.appspot.com/ndt?format=json&policy=metro&metro={metro}
+//	https://mlab-ns.appspot.com/ndt?format=json
+//
+// to return a correctly formatted response refererring to ndt7 servers on either
+// the bare-metal or the auto-joined platform.
+//
+// Traffic from mlab-ns.appspot.com is routed to locate via dispatch.yaml.
+//
+// # Implementation
+//
+// We accept without erroring out the following query parameters:
+//
+//  1. format="" and format="json"
+//  2. policy="", policy="geo", and policy="metro"
+//  3. metro with any non-empty value
+//
+// However, the policy="metro" is silently ignored and remapped to the
+// "geo" policy. This is acceptable because the only requirement is that
+// the output does not break existing clients.
+//
+// The returned status code is as follows:
+//
+//  1. [http.StatusNotImplemented] if the method is not GET.
+//  2. [http.StatusBadRequet] if we do not support the URL options.
+//  3. [http.StatusBadGateway] if the inner call to `/v2/nearest/ndt/ndt7` fails.
+//  4. [http.StatusNoContent] if no servers are available.
+//  5. [http.StatusOK] on success.
+//
+// On success, we return the following JSON structure:
+//
+//	{
+//	  "city": "",
+//	  "country": "",
+//	  "fqdn": "",
+//	  "ip": ["127.0.0.1", "::1"],
+//	  "site": "",
+//	  "url": "",
+//	}
+//
+// where:
+//
+//   - "city" is set to the *actual* city of the ndt7 server.
+//   - "country" is set to the *actual* country of the ndt7 server.
+//   - "fqdn" is set to the *actual* hostname of the ndt7 server.
+//   - "ip" is set to contain specific sentinel values.
+//   - "site" is set to the *actual* site of the ndt7 server.
+//   - "url" is set to the *actual* HTTPS URL of the ndt7 server.
+//
+// This output response has been constructed to avoid breaking parsing of the
+// existing consumer who need the output for documentational purposes.
+//
+// CAVEAT: the returned URL is not actionable to run ndt7 tests.
+//
+// # Metrics
+//
+// This handler emits [metrics.RequestsTotal] with type="mlabns". Because the
+// implementation internally calls [*Client.Nearest] via [httptest.NewRecorder],
+// the inner call also emits its own "nearest" metrics. Therefore, each
+// successful mlab-ns compat request produces two [metrics.RequestsTotal]
+// increments: one for "mlabns" and one for "nearest". This double-counting
+// is intentional: it allows monitoring mlab-ns compat traffic independently
+// while the "nearest" counter reflects the actual load on that code path.
+//
+// # Impact
+//
+// This API endpoint implements the required functionality and effectively
+// cripples all the other existing users of mlab-ns and ndt5. This is completely
+// fine since the support has been extended for two years beyond EOL.
+//
+// # Removal
+//
+// TODO(https://github.com/m-lab/locate/issues/185): this endpoint should not be
+// removed until the affected integrators confirm that it is fine.
+func (c *Client) MLabNSCompat(rw http.ResponseWriter, outerReq *http.Request) {
+	// 1. Set the common headers
+	setHeaders(rw)
+
+	// 2. Transform the outerReq to an innerReq
+	innerReq, ok := mlabnsCompatNewInnerRequest(rw, outerReq)
+	if !ok {
+		return // status code already set
+	}
+
+	// 3. Pass the request to [*Client.Nearest].
+	respRec := httptest.NewRecorder()
+	c.Nearest(respRec, innerReq)
+
+	// 4. Serialize and send the response.
+	mlabnsCompatSerializeAndSendResponse(rw, respRec)
+}
+
+// mlabnsCompatSerializeAndSendResponse writes a response from the [*httptest.ResponseRecorder] that
+// captured the [*Client.Nearest] response. Separated for unit-testability.
+func mlabnsCompatSerializeAndSendResponse(rw http.ResponseWriter, respRec *httptest.ResponseRecorder) {
+	compatResp, ok := mlabnsCompatNewResponse(rw, respRec)
+	if !ok {
+		return // status code already set
+	}
+
+	rw.Header().Set("content-type", "application/json")
+
+	respBody, err := json.Marshal(compatResp)
+	rtx.PanicOnError(err, "Failed to format result") // json.Marshal cannot fail here
+	rw.Write(respBody)
+
+	metrics.RequestsTotal.WithLabelValues("mlabns", "success", http.StatusText(http.StatusOK)).Inc()
+}
+
+// mlabnsCompatNewInnnerRequest parses the `GET /ndt?format=json` request and converts it to
+// the corresponding `GET /v2/nearest/ndt/ndt7` request to send to [*Client.Nearest].
+//
+// This method returns a non-nil request and true, on success, and nil and false, on failure.
+//
+// On failure, the response status code indicating error is set.
+func mlabnsCompatNewInnerRequest(rw http.ResponseWriter, outerReq *http.Request) (*http.Request, bool) {
+	// 1. Parse the request method
+	if outerReq.Method != http.MethodGet {
+		status := http.StatusNotImplemented
+		rw.WriteHeader(status)
+		metrics.RequestsTotal.WithLabelValues("mlabns", "method", http.StatusText(status)).Inc()
+		return nil, false
+	}
+
+	// 2. Parse the query string
+	//
+	// Based on the historical analysis in https://github.com/m-lab/locate/pull/184
+	// most requests include no parameters. When requests included parameters, the
+	// following are most frequent:
+	//
+	//   - no parameters                    0.813
+	//   - format=json                      0.068
+	//   - format=bt&ip=&policy=geo_options 0.059
+	//   - format=json&policy=geo           0.022
+	//   - policy=geo                       0.012
+	//   - policy=geo_options               0.011
+	//   - policy=random                    0.003
+	//   - address_family=ipv4&format=json  0.002
+	//   - address_family=ipv6&format=json  0.002
+	//   - format=json&metro=&policy=metro  0.001
+	//
+	// Supported options:
+	//   - format=json        (default)
+	//   - policy=geo         (default)
+	//   - policy=metro
+	//
+	// In particular, the `policy=metro` is accepted to avoid erroring
+	// clients but not acted upon. The option has no effect.
+	var (
+		format = outerReq.URL.Query().Get("format")
+		policy = outerReq.URL.Query().Get("policy")
+		metro  = outerReq.URL.Query().Get("metro")
+		ok     = true
+	)
+	switch {
+	case format != "" && format != "json": // "json" is the default
+		ok = false
+
+	case policy != "" && policy != "geo" && policy != "metro": // "geo" is the default
+		ok = false
+
+	case policy == "metro" && metro == "": // integrators use this policy w/ a valid metro
+		ok = false
+	}
+	if !ok {
+		status := http.StatusBadRequest
+		rw.WriteHeader(status)
+		metrics.RequestsTotal.WithLabelValues("mlabns", "query", http.StatusText(status)).Inc()
+		return nil, false
+	}
+
+	// 3. Create the inner HTTP request w/ original context
+	innerReq := &http.Request{
+		Method: http.MethodGet,
+		URL: &url.URL{
+			Scheme: outerReq.URL.Scheme,
+			Host:   outerReq.URL.Host,
+			Path:   "/v2/nearest/ndt/ndt7",
+		},
+		Header:     outerReq.Header, // including app-engine headers
+		Host:       outerReq.Host,
+		RemoteAddr: outerReq.RemoteAddr,
+		RequestURI: outerReq.RequestURI,
+		TLS:        outerReq.TLS,
+	}
+	innerReq = innerReq.WithContext(outerReq.Context())
+	return innerReq, true
+}
+
+// mlabnsCompatResponse is the response returned by `GET /ndt?format=json`.
+type mlabnsCompatResponse struct {
+	City    string   `json:"city"`
+	Country string   `json:"country"`
+	FQDN    string   `json:"fqdn"`
+	IP      []string `json:"ip"`
+	Site    string   `json:"site"`
+	URL     string   `json:"url"`
+}
+
+// mlabnsCompatNewResponse parses the recorded response and returns the [*mlabnsCompatResponse].
+//
+// This method returns a non-nil response and true, on success, and nil and false, on failure.
+//
+// On failure, the response status code indicating error is set.
+func mlabnsCompatNewResponse(rw http.ResponseWriter, respRec *httptest.ResponseRecorder) (*mlabnsCompatResponse, bool) {
+	// 1. Handle failure in the inner call.
+	//
+	// Implementation note: we *could* remap 429 to 204 but, in such a case, the clients
+	// would retry after a short delay and we don't want this to happen.
+	if respRec.Code != http.StatusOK {
+		status := http.StatusBadGateway
+		rw.WriteHeader(status)
+		metrics.RequestsTotal.WithLabelValues("mlabns", "inner status", http.StatusText(status)).Inc()
+		return nil, false
+	}
+
+	// 2. Parse the inner call body.
+	//
+	// [http.StatusNoContent] is historically used by mlab-ns to indicate that no servers
+	// are available; see https://github.com/m-lab/locate/pull/184.
+	v2Result := v2.NearestResult{}
+	if err := json.Unmarshal(respRec.Body.Bytes(), &v2Result); err != nil {
+		status := http.StatusBadGateway
+		rw.WriteHeader(status)
+		metrics.RequestsTotal.WithLabelValues("mlabns", "inner json", http.StatusText(status)).Inc()
+		return nil, false
+	}
+	if len(v2Result.Results) <= 0 || v2Result.Results[0].Location == nil {
+		status := http.StatusNoContent
+		rw.WriteHeader(status)
+		metrics.RequestsTotal.WithLabelValues("mlabns", "inner empty", http.StatusText(status)).Inc()
+		return nil, false
+	}
+	res0 := v2Result.Results[0]
+
+	// 3. Assemble the compatibility response
+	ph, err := host.Parse(res0.Machine)
+	if err != nil {
+		status := http.StatusNoContent
+		rw.WriteHeader(status)
+		metrics.RequestsTotal.WithLabelValues("mlabns", "machine", http.StatusText(status)).Inc()
+		return nil, false
+	}
+	fqdn := res0.Hostname
+	compat := &mlabnsCompatResponse{
+		City:    res0.Location.City,
+		Country: res0.Location.Country,
+		FQDN:    fqdn,
+		IP:      []string{"127.0.0.1", "::1"}, // sentinel values
+		Site:    ph.Site,
+		URL:     (&url.URL{Scheme: "https", Host: fqdn, Path: "/"}).String(),
+	}
+	return compat, true
+}

--- a/handler/mlabnscompat.go
+++ b/handler/mlabnscompat.go
@@ -122,8 +122,6 @@ func mlabnsCompatSerializeAndSendResponse(rw http.ResponseWriter, respRec *httpt
 		return // status code already set
 	}
 
-	rw.Header().Set("content-type", "application/json")
-
 	respBody, err := json.Marshal(compatResp)
 	rtx.PanicOnError(err, "Failed to format result") // json.Marshal cannot fail here
 	rw.Write(respBody)

--- a/handler/mlabnscompat_test.go
+++ b/handler/mlabnscompat_test.go
@@ -1,0 +1,387 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	v2 "github.com/m-lab/locate/api/v2"
+	"github.com/m-lab/locate/clientgeo"
+	prom "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_mlabnsCompatNewInnerRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		url        string
+		wantOK     bool
+		wantStatus int
+	}{
+		{
+			name:       "POST method is rejected",
+			method:     http.MethodPost,
+			url:        "/ndt",
+			wantOK:     false,
+			wantStatus: http.StatusNotImplemented,
+		},
+		{
+			name:   "GET with no params succeeds",
+			method: http.MethodGet,
+			url:    "/ndt",
+			wantOK: true,
+		},
+		{
+			name:   "GET with format=json succeeds",
+			method: http.MethodGet,
+			url:    "/ndt?format=json",
+			wantOK: true,
+		},
+		{
+			name:       "GET with format=bt is rejected",
+			method:     http.MethodGet,
+			url:        "/ndt?format=bt",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:   "GET with policy=geo succeeds",
+			method: http.MethodGet,
+			url:    "/ndt?policy=geo",
+			wantOK: true,
+		},
+		{
+			name:   "GET with policy=metro and metro value succeeds",
+			method: http.MethodGet,
+			url:    "/ndt?policy=metro&metro=lga",
+			wantOK: true,
+		},
+		{
+			name:       "GET with policy=metro without metro value is rejected",
+			method:     http.MethodGet,
+			url:        "/ndt?policy=metro",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "GET with policy=random is rejected",
+			method:     http.MethodGet,
+			url:        "/ndt?policy=random",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "GET with policy=geo_options is rejected",
+			method:     http.MethodGet,
+			url:        "/ndt?policy=geo_options",
+			wantOK:     false,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create the outer request with a context to verify propagation.
+			type ctxKey struct{}
+			ctx := context.WithValue(context.Background(), ctxKey{}, "testvalue")
+			outerReq := httptest.NewRequest(tt.method, tt.url, http.NoBody)
+			outerReq = outerReq.WithContext(ctx)
+			outerReq.Header.Set("X-Forwarded-For", "1.2.3.4")
+
+			rw := httptest.NewRecorder()
+			innerReq, ok := mlabnsCompatNewInnerRequest(rw, outerReq)
+
+			assert.Equal(t, tt.wantOK, ok)
+
+			if !tt.wantOK {
+				assert.Nil(t, innerReq)
+				assert.Equal(t, tt.wantStatus, rw.Code)
+				return
+			}
+
+			require.NotNil(t, innerReq)
+			assert.Equal(t, http.MethodGet, innerReq.Method)
+			assert.Equal(t, "/v2/nearest/ndt/ndt7", innerReq.URL.Path)
+			assert.Equal(t, "1.2.3.4", innerReq.Header.Get("X-Forwarded-For"))
+			assert.Equal(t, "testvalue", innerReq.Context().Value(ctxKey{}))
+		})
+	}
+}
+
+// newV2ResponseRecorder creates an [*httptest.ResponseRecorder] that simulates
+// a response from the [*Client.Nearest] handler.
+func newV2ResponseRecorder(code int, body any) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	rec.Code = code
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			panic(err)
+		}
+		rec.Body.Write(data)
+	}
+	return rec
+}
+
+func Test_mlabnsCompatNewResponse(t *testing.T) {
+	// Valid v2 result used by the success case and as a template for partial-failure cases.
+	validResult := v2.NearestResult{
+		Results: []v2.Target{
+			{
+				Machine:  "mlab1-lga0t.mlab-oti.measurement-lab.org",
+				Hostname: "ndt-mlab1-lga0t.mlab-oti.measurement-lab.org",
+				Location: &v2.Location{
+					City:    "New York",
+					Country: "US",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		recorder   *httptest.ResponseRecorder
+		wantOK     bool
+		wantStatus int
+		wantResp   *mlabnsCompatResponse
+	}{
+		{
+			name:       "inner 500 maps to 502",
+			recorder:   newV2ResponseRecorder(http.StatusInternalServerError, nil),
+			wantOK:     false,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "inner 429 maps to 502",
+			recorder:   newV2ResponseRecorder(http.StatusTooManyRequests, nil),
+			wantOK:     false,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name: "invalid JSON body maps to 502",
+			recorder: func() *httptest.ResponseRecorder {
+				rec := httptest.NewRecorder()
+				rec.Code = http.StatusOK
+				rec.Body.WriteString("{garbage")
+				return rec
+			}(),
+			wantOK:     false,
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:       "empty results array maps to 204",
+			recorder:   newV2ResponseRecorder(http.StatusOK, v2.NearestResult{}),
+			wantOK:     false,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name: "nil location maps to 204",
+			recorder: newV2ResponseRecorder(http.StatusOK, v2.NearestResult{
+				Results: []v2.Target{
+					{
+						Machine:  "mlab1-lga0t.mlab-oti.measurement-lab.org",
+						Hostname: "ndt-mlab1-lga0t.mlab-oti.measurement-lab.org",
+						Location: nil,
+					},
+				},
+			}),
+			wantOK:     false,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name: "unparseable machine maps to 204",
+			recorder: newV2ResponseRecorder(http.StatusOK, v2.NearestResult{
+				Results: []v2.Target{
+					{
+						Machine:  "not-a-valid-hostname",
+						Hostname: "not-a-valid-hostname",
+						Location: &v2.Location{
+							City:    "New York",
+							Country: "US",
+						},
+					},
+				},
+			}),
+			wantOK:     false,
+			wantStatus: http.StatusNoContent,
+		},
+		{
+			name:       "valid response produces correct compat output",
+			recorder:   newV2ResponseRecorder(http.StatusOK, validResult),
+			wantOK:     true,
+			wantStatus: http.StatusOK,
+			wantResp: &mlabnsCompatResponse{
+				City:    "New York",
+				Country: "US",
+				FQDN:    "ndt-mlab1-lga0t.mlab-oti.measurement-lab.org",
+				IP:      []string{"127.0.0.1", "::1"},
+				Site:    "lga0t",
+				URL:     "https://ndt-mlab1-lga0t.mlab-oti.measurement-lab.org/",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := httptest.NewRecorder()
+			resp, ok := mlabnsCompatNewResponse(rw, tt.recorder)
+
+			assert.Equal(t, tt.wantOK, ok)
+
+			if !tt.wantOK {
+				assert.Nil(t, resp)
+				assert.Equal(t, tt.wantStatus, rw.Code)
+				return
+			}
+
+			require.NotNil(t, resp)
+			assert.Equal(t, tt.wantResp, resp)
+		})
+	}
+}
+
+func Test_mlabnsCompatSerializeAndSendResponse(t *testing.T) {
+	validResult := v2.NearestResult{
+		Results: []v2.Target{
+			{
+				Machine:  "mlab1-lga0t.mlab-oti.measurement-lab.org",
+				Hostname: "ndt-mlab1-lga0t.mlab-oti.measurement-lab.org",
+				Location: &v2.Location{
+					City:    "New York",
+					Country: "US",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		recorder   *httptest.ResponseRecorder
+		wantStatus int
+		wantBody   bool
+	}{
+		{
+			name:       "inner failure returns 502 with no body",
+			recorder:   newV2ResponseRecorder(http.StatusInternalServerError, nil),
+			wantStatus: http.StatusBadGateway,
+			wantBody:   false,
+		},
+		{
+			name:       "valid inner response returns 200 with JSON body",
+			recorder:   newV2ResponseRecorder(http.StatusOK, validResult),
+			wantStatus: http.StatusOK,
+			wantBody:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rw := httptest.NewRecorder()
+			mlabnsCompatSerializeAndSendResponse(rw, tt.recorder)
+
+			assert.Equal(t, tt.wantStatus, rw.Code)
+
+			if !tt.wantBody {
+				assert.Empty(t, rw.Body.String())
+				return
+			}
+
+			assert.Equal(t, "application/json", rw.Header().Get("content-type"))
+
+			var got mlabnsCompatResponse
+			require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &got))
+			assert.Equal(t, "New York", got.City)
+			assert.Equal(t, "lga0t", got.Site)
+			assert.Equal(t, "ndt-mlab1-lga0t.mlab-oti.measurement-lab.org", got.FQDN)
+		})
+	}
+}
+
+func TestClient_MLabNSCompat(t *testing.T) {
+	validLocator := &fakeLocatorV2{
+		targets: []v2.Target{
+			{
+				Machine:  "mlab1-lga0t.mlab-oti.measurement-lab.org",
+				Hostname: "ndt-mlab1-lga0t.mlab-oti.measurement-lab.org",
+				Location: &v2.Location{City: "New York", Country: "US"},
+			},
+		},
+		urls: []url.URL{
+			{Scheme: "wss", Host: ":3010", Path: "/ndt/v7/download"},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		path       string
+		locator    *fakeLocatorV2
+		wantStatus int
+	}{
+		{
+			name:       "success end-to-end",
+			path:       "/ndt?format=json",
+			locator:    validLocator,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "invalid option returns 400",
+			path:       "/ndt?format=bt",
+			locator:    validLocator,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "locator error propagates as 502",
+			path: "/ndt?format=json",
+			locator: &fakeLocatorV2{
+				err: errors.New("no healthy servers"),
+			},
+			wantStatus: http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient(
+				"mlab-testing",
+				&fakeSigner{},
+				tt.locator,
+				clientgeo.NewAppEngineLocator(),
+				prom.NewAPI(nil),
+				nil, nil, nil, nil, nil,
+			)
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/ndt", c.MLabNSCompat)
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			req, err := http.NewRequest(http.MethodGet, srv.URL+tt.path, http.NoBody)
+			require.NoError(t, err)
+			req.Header.Set("X-AppEngine-CityLatLong", "40.3,-70.4")
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			if tt.wantStatus != http.StatusOK {
+				return
+			}
+
+			var got mlabnsCompatResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+			assert.Equal(t, "New York", got.City)
+			assert.Equal(t, "US", got.Country)
+			assert.Equal(t, "ndt-mlab1-lga0t.mlab-oti.measurement-lab.org", got.FQDN)
+			assert.Equal(t, "lga0t", got.Site)
+			assert.Equal(t, []string{"127.0.0.1", "::1"}, got.IP)
+		})
+	}
+}

--- a/handler/mlabnscompat_test.go
+++ b/handler/mlabnscompat_test.go
@@ -292,8 +292,6 @@ func Test_mlabnsCompatSerializeAndSendResponse(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, "application/json", rw.Header().Get("content-type"))
-
 			var got mlabnsCompatResponse
 			require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &got))
 			assert.Equal(t, "New York", got.City)
@@ -370,6 +368,15 @@ func TestClient_MLabNSCompat(t *testing.T) {
 			defer resp.Body.Close()
 
 			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			// Verify all headers set by setHeaders are present regardless
+			// of success or failure, since MLabNSCompat calls setHeaders
+			// unconditionally before any status-code logic.
+			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+			assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+			assert.Equal(t, "GET, OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
+			assert.Equal(t, "Authorization", resp.Header.Get("Access-Control-Allow-Headers"))
+			assert.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
 
 			if tt.wantStatus != http.StatusOK {
 				return

--- a/locate.go
+++ b/locate.go
@@ -274,14 +274,23 @@ func main() {
 		monitoringChain))
 
 	// USER APIs
+	//
 	// Clients request access tokens for specific services.
 	mux.HandleFunc("/v2/nearest/", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(promet.Labels{"path": "/v2/nearest/"}),
 		http.HandlerFunc(c.Nearest)))
+
 	// REQUIRED: API keys parameters required for priority requests.
 	mux.HandleFunc("/v2/priority/nearest/", promhttp.InstrumentHandlerDuration(
 		metrics.RequestHandlerDuration.MustCurryWith(promet.Labels{"path": "/v2/priority/nearest/"}),
 		http.HandlerFunc(c.PriorityNearest)))
+
+	// DEPRECATED USER APIs
+	//
+	// TODO(https://github.com/m-lab/locate/issues/185).
+	mux.HandleFunc("/ndt", promhttp.InstrumentHandlerDuration(
+		metrics.RequestHandlerDuration.MustCurryWith(promet.Labels{"path": "/ndt"}),
+		http.HandlerFunc(c.MLabNSCompat)))
 
 	// Liveness and Readiness checks to support deployments.
 	mux.HandleFunc("/v2/live", c.Live)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -222,6 +222,39 @@ paths:
       tags:
         - siteinfo
 
+  # Legacy mlab-ns compatibility
+  # TODO(https://github.com/m-lab/locate/issues/185)
+  "/ndt":
+    get:
+      description: |-
+        Compatibility endpoint for the retired mlab-ns /ndt resource.
+
+        This endpoint exists solely to support known integrators that have not
+        yet completed their migration away from mlab-ns. It returns ndt7 server
+        metadata in the legacy mlab-ns JSON format.
+
+        No support is offered for this resource. It will be removed once affected
+        integrators confirm they no longer depend on it.
+
+        See https://github.com/m-lab/locate/issues/185.
+
+      operationId: "v1-ndt"
+      produces:
+      - "application/json"
+      responses:
+        '200':
+          description: The result of the request.
+        '204':
+          description: No results available.
+        '400':
+          description: Unsupported query parameter value.
+        '501':
+          description: Unsupported HTTP method.
+        '502':
+          description: The inner nearest lookup failed.
+      tags:
+        - public
+
 definitions:
   # Define the query reply without being specific about the structure.
   ErrorResult:


### PR DESCRIPTION
We implement a minimal mlab-ns compatibility shim.

The service has been EOL for a long time now. We recently reached out to integrators and it seems there are still some that need a small compatibility shim to avoid breaking legacy applications.

Their migration is fully underway, but there needs to be time to migrate a fleet of legacy clients, which are using the output of mlab-ns for archival purposes.

Accordingly, this pull request implements just the minimum functionality to avoid breaking those applications. Yet, note that the returned response is not actionable anymore for running ndt5 tests (and it can't be used for running ndt7 tests either).

The complete plan is this:

1. merge this diff

2. deploy

3. use `dispatch.yaml` to route to `locate`

4. discontinue `mlab-ns`

5. wait for the legacy applications queue to drain

6. circle back and zap this diff

This is probably the last chapter in mlab-ns glorious life.

See https://github.com/m-lab/locate/issues/185.

Adapted from https://github.com/m-lab/locate/pull/184.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/252)
<!-- Reviewable:end -->
