### PR TITLE
doc(openapi.yaml): document /v2/nearest query params

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -47,6 +47,10 @@ paths:
         This resource does not require an API key. All requests to this resource
         are managed collectively as if they all used a single API key.
 
+        Any query parameter prefixed with "client_" is forwarded to the
+        measurement server URLs. By convention, integrations should pass
+        "client_name" (application identifier) and "client_version".
+
       operationId: "v2-shared-nearest"
       produces:
       - "application/json"
@@ -61,6 +65,35 @@ paths:
           description: The service type, e.g. "ndt7", "dash", "replay", etc.
           type: string
           required: true
+        - name: lat
+          in: query
+          description: |-
+            Client latitude (-90 to 90). Must be used together with "lon".
+            When both are provided, the locate API uses these coordinates
+            instead of IP-based geolocation to find the nearest servers.
+            Takes priority over "region" and "country".
+          type: number
+          format: double
+          required: false
+        - name: lon
+          in: query
+          description: |-
+            Client longitude (-180 to 180). Must be used together with "lat".
+            When both are provided, the locate API uses these coordinates
+            instead of IP-based geolocation to find the nearest servers.
+            Takes priority over "region" and "country".
+          type: number
+          format: double
+          required: false
+        - name: region
+          in: query
+          description: |-
+            ISO 3166-2 region/subdivision code (e.g. "US-NY", "KE-30").
+            When provided, the locate API resolves the client position to
+            the geographic center of the given region. Takes priority over
+            "country" but is overridden by "lat"/"lon".
+          type: string
+          required: false
         - name: site
           in: query
           description: |-
@@ -133,6 +166,10 @@ paths:
         load that the locate API must choose which requests to allow and which
         to reject, these requests are prioritized over "shared" requests.
 
+        Any query parameter prefixed with "client_" is forwarded to the
+        measurement server URLs. By convention, integrations should pass
+        "client_name" (application identifier) and "client_version".
+
       operationId: "v2-priority-nearest"
       produces:
       - "application/json"
@@ -147,6 +184,35 @@ paths:
           description: datatype
           type: string
           required: true
+        - name: lat
+          in: query
+          description: |-
+            Client latitude (-90 to 90). Must be used together with "lon".
+            When both are provided, the locate API uses these coordinates
+            instead of IP-based geolocation to find the nearest servers.
+            Takes priority over "region" and "country".
+          type: number
+          format: double
+          required: false
+        - name: lon
+          in: query
+          description: |-
+            Client longitude (-180 to 180). Must be used together with "lat".
+            When both are provided, the locate API uses these coordinates
+            instead of IP-based geolocation to find the nearest servers.
+            Takes priority over "region" and "country".
+          type: number
+          format: double
+          required: false
+        - name: region
+          in: query
+          description: |-
+            ISO 3166-2 region/subdivision code (e.g. "US-NY", "KE-30").
+            When provided, the locate API resolves the client position to
+            the geographic center of the given region. Takes priority over
+            "country" but is overridden by "lat"/"lon".
+          type: string
+          required: false
         - name: site
           in: query
           description: |-

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -61,6 +61,50 @@ paths:
           description: The service type, e.g. "ndt7", "dash", "replay", etc.
           type: string
           required: true
+        - name: site
+          in: query
+          description: |-
+            Limit results to machines at the specified site(s). Repeat the
+            parameter to include multiple sites, e.g. "?site=lga01&site=mil05".
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          required: false
+        - name: country
+          in: query
+          description: |-
+            ISO 3166-1 alpha-2 country code. When provided (without "strict"),
+            the locate API resolves the client position to the geographic center
+            of the given country and returns the nearest servers to that point.
+            For example, "?country=AU" returns servers closest to Australia
+            regardless of where the request actually originates.
+          type: string
+          required: false
+        - name: strict
+          in: query
+          description: |-
+            Requires "country". When both are set, the locate API uses the
+            client's real IP-based location instead of repositioning to the
+            country center, and only returns servers physically located in the
+            specified country. Returns an error if no servers exist there.
+          type: boolean
+          required: false
+        - name: org
+          in: query
+          description: |-
+            Limit results to servers operated by a specific organization.
+            Use "mlab" for M-Lab managed infrastructure. Other values
+            correspond to Autonode partner identifiers.
+          type: string
+          required: false
+        - name: machine-type
+          in: query
+          description: |-
+            Limit results to a specific machine type. Valid values are
+            "physical" (bare-metal servers) and "virtual" (virtual machines).
+          type: string
+          required: false
       responses:
         # NOTE: non-number values are a schema error for the config, despite
         # openapi documentation.
@@ -103,6 +147,50 @@ paths:
           description: datatype
           type: string
           required: true
+        - name: site
+          in: query
+          description: |-
+            Limit results to machines at the specified site(s). Repeat the
+            parameter to include multiple sites, e.g. "?site=lga01&site=mil05".
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          required: false
+        - name: country
+          in: query
+          description: |-
+            ISO 3166-1 alpha-2 country code. When provided (without "strict"),
+            the locate API resolves the client position to the geographic center
+            of the given country and returns the nearest servers to that point.
+            For example, "?country=AU" returns servers closest to Australia
+            regardless of where the request actually originates.
+          type: string
+          required: false
+        - name: strict
+          in: query
+          description: |-
+            Requires "country". When both are set, the locate API uses the
+            client's real IP-based location instead of repositioning to the
+            country center, and only returns servers physically located in the
+            specified country. Returns an error if no servers exist there.
+          type: boolean
+          required: false
+        - name: org
+          in: query
+          description: |-
+            Limit results to servers operated by a specific organization.
+            Use "mlab" for M-Lab managed infrastructure. Other values
+            correspond to Autonode partner identifiers.
+          type: string
+          required: false
+        - name: machine-type
+          in: query
+          description: |-
+            Limit results to a specific machine type. Valid values are
+            "physical" (bare-metal servers) and "virtual" (virtual machines).
+          type: string
+          required: false
       responses:
         '200':
           description: The result of the nearest request. Clients should use the


### PR DESCRIPTION
This commit adds openapi.yaml documentation for the /v2/nearest query params. According to [upstream documentation][upstream]:

> ESP and ESPv2 ignore most parameter and type definitions [...]
> don't enforce parameter and type definitions [...] and forwards
> incoming requests to your API.

Based on this, there should be no functional change.

[upstream]: https://docs.cloud.google.com/endpoints/docs/openapi/openapi-limitations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/locate/264)
<!-- Reviewable:end -->
